### PR TITLE
Normalize extra newlines.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -24,7 +24,10 @@ module.exports = function parse (srt) {
 
   srt = srt.trim()
   srt += '\n'
-  srt = srt.replace(/\r\n/g, '\n').split('\n')
+  srt = srt
+    .replace(/\r\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .split('\n')
 
   srt.forEach(function (line) {
     line = line.toString()


### PR DESCRIPTION
This PR fixes errors that happen when srt's contain extra newlines.
For example:
```txt
22
00:04:30,868 --> 00:04:30,946


23
00:04:32,711 --> 00:04:34,806
```

Currently if the parser hits the extra blank line it treats it like an entry and will fail to parse its `toMS`.