### PR TITLE
Ensure `text` is an empty string instead of `null` or `undefined`

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -58,7 +58,7 @@ module.exports = function parse (srt) {
         start: start,
         end: end,
         duration: toMS(end) - toMS(start),
-        text: text
+        text: text || ''
       })
       index = time = start = end = text = null
     } else {


### PR DESCRIPTION
This PR ensures `text` is `""` when empty instead of `undefined` or `null`.