### PR TITLE
Fix parsing of 00:00:00,000 timestamp

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -30,7 +30,7 @@ module.exports = function parse (srt) {
       }
     }
 
-    if (!caption.start) {
+    if (!caption.hasOwnProperty('start')) {
       Object.assign(caption, parseTimestamps(row))
       return captions
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subtitle",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Parse and manipulate SRT (SubRip)",
   "repository": {
     "type": "git",

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -58,3 +58,21 @@ Welcome to the Planet.
 test('it should an empty array', t => {
   t.deepEqual(parse(), [])
 })
+
+test('parse 00:00:00,000 caption', t => {
+  const srt = `
+1
+00:00:00,000 --> 00:00:00,100
+Hi.
+`
+  const value = parse(srt)
+  const expected = [
+    {
+      start: 0,
+      end: 100,
+      text: 'Hi.'
+    }
+  ]
+
+  t.deepEqual(value, expected)
+})


### PR DESCRIPTION
When a zero timestamp was parsed, caption.start was set to 0
and the check !caption.start failed.
Fixed by using hasOwnProperty()

Many thanks to @frankplus for catching this.