### PR TITLE
Add stringifyVtt to complement parse which already supports WebVTT input

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ also supported.
 ```js
 // ES2015 modules
 import * as Subtitle from 'subtitle'
-import { parse, stringify, resync, toMS, toSrtTime } from 'subtitle'
+import { parse, stringify, stringifyVtt, resync, toMS, toSrtTime, toVttTime } from 'subtitle'
 ```
 
 ```js
 // ES6 CommonJS
 const Subtitle = require('subtitle')
-const { parse, stringify, resync, toMS, toSrtTime } = require('subtitle')
+const { parse, stringify, stringifyVtt, resync, toMS, toSrtTime, toVttTime } = require('subtitle')
 ```
 
 ```js
@@ -35,9 +35,11 @@ const { parse, stringify, resync, toMS, toSrtTime } = require('subtitle')
 var Subtitle = require('subtitle')
 Subtitle.parse
 Subtitle.stringify
+Subtitle.stringifyVtt
 Subtitle.resync
 Subtitle.toMS
 Subtitle.toSrtTime
+Subtitle.toVttTime
 ```
 
 ### Browser
@@ -55,21 +57,25 @@ script `subtitle.bundle.js` from the `dist` folder and link it to your page.
       parse: function parse()
       resync: function resync()
       stringify: function stringify()
+      stringifyVtt: function stringifyVtt()
       toMS: function toMS()
       toSrtTime: function toSrtTime()
+      toVttTime: function toVttTime()
   */
 </script>
 ```
 
 ## API
 
-The API is minimal and provide only five functions:
+The API is minimal and provide only five functions, two of which have SRT and WebVTT variants:
 
 * [`parse`](#parsesrt-string---array)
-* [`stringify`](#stringifysubtitles-array---string)
-* [`resync`](#resyncsubtitles-array-time-number---object)
+* [`stringify`](#stringifycaptions-array---string)
+* [`stringifyVtt`](#stringifycaptions-array---string)
+* [`resync`](#resynccaptions-array-time-number---object)
 * [`toMS`](#tomstimestamp-string---number)
 * [`toSrtTime`](#tosrttimetimestamp-number---string)
+* [`toVttTime`](#tovtttimetimestamp-number---string)
 
 ### `parse(srt: String) -> Array`
 
@@ -96,6 +102,9 @@ parse(mySrtOrVttContent)
 
 The reverse of `parse`. It gets an array with subtitles and converts it to a valid SRT string.
 
+The `stringifyVtt(captions: Array) -> String` function is also available for converting to a 
+valid WebVTT string.
+
 ```js
 const subtitles = [
   {
@@ -106,7 +115,8 @@ const subtitles = [
   {
     start: 24600, // timestamp in milliseconds is supported as well
     end: 27800,
-    text: 'Bla Bla Bla Bla'
+    text: 'Bla Bla Bla Bla',
+    settings: 'align:middle line:90%' // Ignored in SRT format
   }
 ]
 
@@ -119,6 +129,20 @@ Bla Bla Bla Bla
 
 2
 00:00:24,600 --> 00:00:27,800
+Bla Bla Bla Bla
+*/
+
+const vtt = stringifyVtt(subtitles)
+// returns the following string:
+/*
+WEBVTT
+
+1
+00:00:20.000 --> 00:00:24.400
+Bla Bla Bla Bla
+
+2
+00:00:24.600 --> 00:00:27.800 align:middle line:90%
 Bla Bla Bla Bla
 */
 ```
@@ -170,6 +194,16 @@ Convert a time from milliseconds to a SRT timestamp:
 ```js
 toSrtTime(24400)
 // '00:00:24,400'
+```
+
+
+### `toVttTime(timestamp: Number) -> String`
+
+Convert a time from milliseconds to a WebVTT timestamp:
+
+```js
+toVttTime(24400)
+// '00:00:24.400'
 ```
 
 ## Tests

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
 export { default as toMS } from './toMS'
 export { default as toSrtTime } from './toSrtTime'
+export { default as toVttTime } from './toVttTime'
 export { default as parse } from './parse'
 export { default as stringify } from './stringify'
+export { default as stringifyVtt } from './stringifyVtt'
 export { default as resync } from './resync'
 export { default as parseTimestamps } from './parseTimestamps'

--- a/lib/stringifyVtt.js
+++ b/lib/stringifyVtt.js
@@ -1,0 +1,21 @@
+/**
+ * Module dependencies.
+ */
+
+import toVttTime from './toVttTime'
+
+/**
+ * Stringify the given array of captions to WebVTT format.
+ * @param {Array} captions
+ * @return {String} webVtt
+ */
+
+export default function stringifyVtt (captions) {
+  return 'WEBVTT\n\n' + captions.map((caption, index) => {
+    return (index > 0 ? '\n' : '') + [
+      index + 1,
+      `${toVttTime(caption.start)} --> ${toVttTime(caption.end)}${caption.settings ? ' ' + caption.settings : ''}`,
+      caption.text
+    ].join('\n')
+  }).join('\n') + '\n'
+}

--- a/lib/toVttTime.js
+++ b/lib/toVttTime.js
@@ -1,0 +1,26 @@
+/**
+ * Module dependencies.
+ */
+
+import zeroFill from 'zero-fill'
+
+/**
+ * Return the given milliseconds as WebVTT timestamp.
+ * @param timestamp
+ * @returns {string}
+ */
+
+export default function toVttTime (timestamp) {
+  if (isNaN(timestamp)) {
+    return timestamp
+  }
+
+  const date = new Date(0, 0, 0, 0, 0, 0, timestamp)
+
+  const hours = zeroFill(2, date.getHours())
+  const minutes = zeroFill(2, date.getMinutes())
+  const seconds = zeroFill(2, date.getSeconds())
+  const ms = timestamp - ((hours * 3600000) + (minutes * 60000) + (seconds * 1000))
+
+  return `${hours}:${minutes}:${seconds}.${zeroFill(3, ms)}`
+}

--- a/test/examples/La.La.Land.2016.1080p.BluRay.x264-SPARKS.EN.vtt
+++ b/test/examples/La.La.Land.2016.1080p.BluRay.x264-SPARKS.EN.vtt
@@ -1,0 +1,6144 @@
+WEBVTT
+
+1
+00:00:00.001 --> 00:00:05.000
+Subtitles: @marlonrock1986 (^^V^^)
+
+2
+00:00:25.801 --> 00:00:28.700
+It's another hot, sunny day today
+here in Southern California.
+
+3
+00:00:28.801 --> 00:00:30.900
+Temperature is 84�F
+for downtown Los Angeles.
+
+4
+00:00:30.901 --> 00:00:33.000
+Overnight lows of 75. [...]
+
+5
+00:01:05.401 --> 00:01:07.300
+<i>Ba-ba-da ba-da ba-da-ba-ba</i>
+
+6
+00:01:07.401 --> 00:01:09.200
+<i>Ba-ba-da ba-da ba-da-ba-ba</i>
+
+7
+00:01:09.301 --> 00:01:11.100
+<i>Ba-ba-da ba-da ba-da-ba-ba</i>
+
+8
+00:01:11.201 --> 00:01:12.600
+<i>Ba-ba-ba</i>
+
+9
+00:01:12.701 --> 00:01:14.800
+<i>I think about that day</i>
+
+10
+00:01:14.801 --> 00:01:17.000
+<i>I left him
+at a Greyhound station</i>
+
+11
+00:01:17.001 --> 00:01:18.500
+<i>west of Santa Fe</i>
+
+12
+00:01:18.501 --> 00:01:22.200
+<i>We were seventeen,
+but he was sweet and it was true</i>
+
+13
+00:01:22.301 --> 00:01:25.900
+<i>Still I did
+what I had to do</i>
+
+14
+00:01:25.901 --> 00:01:28.000
+<i>'Cause I just knew</i>
+
+15
+00:01:28.101 --> 00:01:29.800
+<i>Summer, sunday nights</i>
+
+16
+00:01:29.801 --> 00:01:33.600
+<i>We'd sink into our seats
+right as they dimmed out all the lights</i>
+
+17
+00:01:33.701 --> 00:01:37.500
+<i>A Technicolor world made out
+of music and machine,</i>
+
+18
+00:01:37.601 --> 00:01:41.200
+<i>It called me
+to be on that screen</i>
+
+19
+00:01:41.201 --> 00:01:43.200
+<i>And live inside each scene</i>
+
+20
+00:01:43.201 --> 00:01:47.300
+<i>Without a nickel to my name,
+Hopped a bus, here I came</i>
+
+21
+00:01:47.401 --> 00:01:49.500
+<i>Could be brave
+or just insane,</i>
+
+22
+00:01:49.501 --> 00:01:51.000
+<i>We'll have to see</i>
+
+23
+00:01:51.001 --> 00:01:52.900
+<i>'Cause maybe
+in that sleepy town</i>
+
+24
+00:01:53.001 --> 00:01:54.800
+<i>He'll sit one day,
+the lights are down,</i>
+
+25
+00:01:54.901 --> 00:01:58.700
+<i>He'll see my face and think
+of how he used to know me</i>
+
+26
+00:01:58.801 --> 00:02:02.100
+<i>Climb these hills
+I'm reaching for the heights</i>
+
+27
+00:02:02.201 --> 00:02:06.000
+<i>And chasing
+all the lights that shine</i>
+
+28
+00:02:06.101 --> 00:02:09.900
+<i>And when they let you down,
+(It's another day of...)</i>
+
+29
+00:02:10.001 --> 00:02:13.700
+<i>You get up off the ground,
+(It's another day of...)</i>
+
+30
+00:02:13.801 --> 00:02:20.800
+<i>'Cause morning rolls around
+and it's another day of sun</i>
+
+31
+00:02:21.401 --> 00:02:23.400
+<i>I hear'em ev'ry day,</i>
+
+32
+00:02:23.401 --> 00:02:27.000
+<i>The rhythms in the canyons
+that'll never fade away,</i>
+
+33
+00:02:27.101 --> 00:02:30.800
+<i>The ballads in the barrooms
+left by those who came before</i>
+
+34
+00:02:30.901 --> 00:02:34.400
+<i>They say
+"you gotta want it more"</i>
+
+35
+00:02:34.401 --> 00:02:36.600
+<i>So I bang on ev'ry door</i>
+
+36
+00:02:36.601 --> 00:02:38.700
+<i>And even
+when the answer's "no"</i>
+
+37
+00:02:38.801 --> 00:02:40.600
+<i>Or when my money's
+running low,</i>
+
+38
+00:02:40.701 --> 00:02:42.900
+<i>The dusty mic
+and neon glow</i>
+
+39
+00:02:42.901 --> 00:02:44.300
+<i>Are all I need</i>
+
+40
+00:02:44.301 --> 00:02:46.300
+<i>And someday,
+as I sing my song,</i>
+
+41
+00:02:46.401 --> 00:02:48.300
+<i>A small-town kid'll
+come along</i>
+
+42
+00:02:48.401 --> 00:02:52.100
+<i>That'll be the thing to push him on
+and go, go</i>
+
+43
+00:02:52.201 --> 00:02:55.600
+<i>Climb these hills
+I'm reaching for the heights</i>
+
+44
+00:02:55.701 --> 00:02:59.400
+<i>And chasing
+all the lights that shine</i>
+
+45
+00:02:59.501 --> 00:03:03.200
+<i>And when they let you down,
+(It's another day of...)</i>
+
+46
+00:03:03.301 --> 00:03:07.100
+<i>You get up off the ground,
+('Cause it's another day of...)</i>
+
+47
+00:03:07.201 --> 00:03:14.200
+<i>'Cause morning rolls around
+and it's another day of sun</i>
+
+48
+00:03:45.401 --> 00:03:49.200
+<i>And when they let you down,</i>
+
+49
+00:03:49.301 --> 00:03:52.200
+<i>The morning rolls around</i>
+
+50
+00:03:52.201 --> 00:03:55.900
+<i>It's another day of sun
+(Oh)</i>
+
+51
+00:03:56.001 --> 00:03:59.800
+<i>It's another day of sun
+(Oh)</i>
+
+52
+00:03:59.901 --> 00:04:03.100
+<i>It's another day of sun
+(Sun [...])</i>
+
+53
+00:04:03.201 --> 00:04:06.800
+<i>It's another day of sun
+(Oh)</i>
+
+54
+00:04:06.901 --> 00:04:10.900
+<i>Just another day of sun
+(Oh)</i>
+
+55
+00:04:11.001 --> 00:04:14.600
+<i>It's another day of sun
+(Sun)</i>
+
+56
+00:04:14.701 --> 00:04:20.200
+<i>Another day has just begun
+(Oh)</i>
+
+57
+00:04:20.201 --> 00:04:22.900
+<i>It's another day of sun</i>
+
+58
+00:04:39.201 --> 00:04:41.400
+<i>It's another day of sun</i>
+
+59
+00:04:50.201 --> 00:04:53.200
+WINTER
+
+60
+00:04:53.301 --> 00:04:55.800
+[...] already has won three Oscars,
+
+61
+00:04:55.801 --> 00:05:00.600
+including for the 1998 film
+"Shakespeare in Love".
+
+62
+00:05:25.101 --> 00:05:28.700
+[...] I mean, we could not
+believe what was happening.
+
+63
+00:05:28.801 --> 00:05:32.700
+No, I swear to God.
+She was wrecked!
+
+64
+00:05:32.801 --> 00:05:36.000
+She was completely wrecked!
+I know!
+
+65
+00:05:36.101 --> 00:05:40.400
+I know, it-it was...
+it was pure insanity.
+
+66
+00:05:40.401 --> 00:05:42.800
+"It's insanity?"
+
+67
+00:05:42.901 --> 00:05:44.300
+Ah!
+
+68
+00:05:44.401 --> 00:05:47.800
+Lunacy! "It was pure lunacy."
+
+69
+00:05:57.501 --> 00:06:00.000
+What is his problem?
+I should go.
+
+70
+00:06:07.801 --> 00:06:10.200
+- Cappuccino, please.
+- Right, of course.
+
+71
+00:06:10.301 --> 00:06:14.400
+- On us.
+- Oh! No, thank you. I insist.
+
+72
+00:06:25.601 --> 00:06:28.600
+Did you see who that was?
+
+73
+00:06:43.501 --> 00:06:44.800
+Audition!
+
+74
+00:06:45.601 --> 00:06:47.000
+Shit.
+
+75
+00:06:47.301 --> 00:06:48.700
+Mia, where d'you think
+you're going?
+
+76
+00:06:48.701 --> 00:06:50.000
+Oh. To see a doctor.
+
+77
+00:06:50.001 --> 00:06:51.700
+You better be here
+early tomorrow.
+
+78
+00:06:51.701 --> 00:06:53.100
+Okay.
+
+79
+00:06:53.801 --> 00:06:55.700
+Have a good night!
+
+80
+00:07:09.401 --> 00:07:11.900
+She was wrecked!
+
+81
+00:07:11.901 --> 00:07:13.900
+It was pure lunacy!
+It was...
+
+82
+00:07:13.901 --> 00:07:16.800
+It was so crazy and I just...
+
+83
+00:07:16.901 --> 00:07:19.300
+Oh, you would've died.
+
+84
+00:07:20.301 --> 00:07:24.400
+No, Turner's fine. Turner's fine.
+I-I just, uh...
+
+85
+00:07:25.201 --> 00:07:28.800
+Are you going to wait until Denver
+to tell her, or...?
+
+86
+00:07:31.801 --> 00:07:33.600
+What?
+
+87
+00:07:42.301 --> 00:07:44.200
+Okay.
+
+88
+00:07:48.701 --> 00:07:51.100
+No, I'm happy for you.
+
+89
+00:07:53.101 --> 00:07:55.800
+I am, I'm happy for you.
+I just...
+
+90
+00:07:58.201 --> 00:08:00.400
+I just thought...
+
+91
+00:08:03.501 --> 00:08:05.100
+- I don't know what I thought.
+- One second.
+
+92
+00:08:05.101 --> 00:08:06.100
+I guess it just [...]
+
+93
+00:08:07.901 --> 00:08:10.500
+- What, Ruby?
+- Jessica on the phone.
+
+94
+00:08:10.601 --> 00:08:14.900
+- Uh... Tell her I'll call her back.
+- In two minutes?
+
+95
+00:08:15.201 --> 00:08:16.300
+Less than two minutes.
+
+96
+00:08:16.301 --> 00:08:19.500
+- I'll go get your lunch.
+- I'm almost done. Thank you.
+
+97
+00:08:27.301 --> 00:08:30.000
+Oh. You know what?
+I think we're good.
+
+98
+00:08:30.001 --> 00:08:31.900
+Thanks for coming in.
+
+99
+00:09:34.701 --> 00:09:37.800
+Wow! Holy shit!
+You wanna open a window?
+
+100
+00:09:37.901 --> 00:09:39.500
+It was trying to give you
+an entrance.
+
+101
+00:09:39.501 --> 00:09:40.800
+Thank you.
+
+102
+00:09:40.901 --> 00:09:43.800
+Mia! How'd the audition go?!
+
+103
+00:09:44.101 --> 00:09:45.800
+- Er...
+- Er, same here.
+
+104
+00:09:45.801 --> 00:09:47.200
+Was Jen there? Or Rachel?
+
+105
+00:09:47.201 --> 00:09:48.900
+I don't know
+who Jen and Rachel are.
+
+106
+00:09:48.901 --> 00:09:50.100
+Are the worst.
+
+107
+00:09:50.101 --> 00:09:52.100
+Oh, I don't know
+if they were there.
+
+108
+00:09:52.101 --> 00:09:53.200
+Bet that they were.
+
+109
+00:09:53.201 --> 00:09:55.300
+Why is there a convention
+in the bathroom?
+
+110
+00:09:55.301 --> 00:09:56.300
+Agreed.
+
+111
+00:09:56.301 --> 00:09:59.200
+Two minutes, people!
+Mia, you're coming, right?!
+
+112
+00:09:59.201 --> 00:10:00.700
+I can't!
+
+113
+00:10:00.801 --> 00:10:01.900
+I'm working.
+
+114
+00:10:02.001 --> 00:10:03.200
+What?!
+
+115
+00:10:03.501 --> 00:10:05.800
+Did she just say "working"?
+
+116
+00:10:07.101 --> 00:10:09.000
+- What?
+- I'm sorry it didn't go well today,
+
+117
+00:10:09.101 --> 00:10:10.400
+and there's like four things
+in my inbox
+
+118
+00:10:10.501 --> 00:10:12.300
+that you're perfect for
+and I will submit you.
+
+119
+00:10:12.301 --> 00:10:14.300
+But right now, you're coming!
+
+120
+00:10:14.301 --> 00:10:16.500
+- It will be fun.
+- It's not gonna be fun.
+
+121
+00:10:16.601 --> 00:10:18.000
+- It could be.
+- It's not.
+
+122
+00:10:18.101 --> 00:10:20.000
+It's gonna be a bunch
+of social climbers,
+
+123
+00:10:20.101 --> 00:10:22.500
+all packed into one
+of those big glass houses.
+
+124
+00:10:22.501 --> 00:10:24.100
+This looks familiar.
+
+125
+00:10:24.101 --> 00:10:26.500
+- I was gonna give that back.
+- How long have you had this?!
+
+126
+00:10:26.601 --> 00:10:28.500
+- Oh, a long time.
+- Come on, Mia!
+
+127
+00:10:28.601 --> 00:10:29.700
+When else
+are you gonna get to see
+
+128
+00:10:29.801 --> 00:10:32.200
+a very Hollywood cliche
+crammed into the same room?
+
+129
+00:10:32.201 --> 00:10:34.000
+We'll make fun of it together!
+
+130
+00:10:34.001 --> 00:10:36.800
+"I'm disappointed in you, Lex."
+There's nothing to make fun of.
+
+131
+00:10:36.901 --> 00:10:39.700
+This party is gonna be like...
+humanity at its finest.
+
+132
+00:10:39.701 --> 00:10:40.700
+Hmm.
+
+133
+00:10:40.701 --> 00:10:44.200
+<i>- You got the invitation
+- You got the right address</i>
+
+134
+00:10:44.301 --> 00:10:48.000
+<i>- You need some medication?
+- The answer's always yes</i>
+
+135
+00:10:48.001 --> 00:10:50.100
+<i>A little chance encounter</i>
+
+136
+00:10:50.101 --> 00:10:52.500
+<i>Could be the one
+you've waited for</i>
+
+137
+00:10:52.501 --> 00:10:53.500
+Oh!
+
+138
+00:10:53.601 --> 00:10:55.600
+<i>Just squeeze a bit more!</i>
+
+139
+00:10:55.601 --> 00:10:59.200
+<i>Tonight we're on a mission
+Tonight's the casting call</i>
+
+140
+00:10:59.201 --> 00:11:01.200
+<i>If this is the real audition</i>
+
+141
+00:11:01.301 --> 00:11:03.000
+<i>Oh, God help us all!</i>
+
+142
+00:11:03.001 --> 00:11:08.200
+<i>You make the right impression,
+Then ev'rybody knows your name</i>
+
+143
+00:11:08.201 --> 00:11:10.400
+<i>We're in the fast lane</i>
+
+144
+00:11:10.401 --> 00:11:14.000
+<i>Someone in the crowd could be
+the one you need to know,</i>
+
+145
+00:11:14.101 --> 00:11:17.800
+<i>The one to fin'lly
+lift you off the ground</i>
+
+146
+00:11:17.901 --> 00:11:21.300
+<i>Someone in the crowd
+could take you where you wanna go</i>
+
+147
+00:11:21.401 --> 00:11:23.900
+<i>If you're the someone
+ready to be found</i>
+
+148
+00:11:24.001 --> 00:11:26.400
+<i>The someone
+ready to be found</i>
+
+149
+00:11:26.501 --> 00:11:30.200
+<i>Do what you need to do
+'til they discover you</i>
+
+150
+00:11:30.301 --> 00:11:34.000
+<i>And make you more
+than who you're seeing now</i>
+
+151
+00:11:34.101 --> 00:11:37.900
+<i>- So with the stars aligned
+- I think I'll stay behind</i>
+
+152
+00:11:37.901 --> 00:11:42.400
+<i>You've got to go and find</i>
+
+153
+00:11:43.001 --> 00:11:45.800
+<i>That someone in the crowd</i>
+
+154
+00:12:11.701 --> 00:12:13.200
+Hey girl!
+
+155
+00:12:13.301 --> 00:12:15.000
+Uhuh.
+
+156
+00:12:15.301 --> 00:12:19.400
+<i>That someone in the crowd!</i>
+
+157
+00:13:27.301 --> 00:13:30.800
+<i>Is someone in the crowd</i>
+
+158
+00:13:30.801 --> 00:13:35.400
+<i>the only thing
+you really see?</i>
+
+159
+00:13:36.101 --> 00:13:43.900
+<i>Watching while the world
+keeps spinning 'round?</i>
+
+160
+00:13:44.701 --> 00:13:53.300
+<i>Somewhere there's a place
+where I find who I'm gonna be,</i>
+
+161
+00:13:54.201 --> 00:13:56.300
+<i>A somewhere</i>
+
+162
+00:13:56.301 --> 00:14:02.800
+<i>that's just waiting
+to be found</i>
+
+163
+00:14:49.001 --> 00:14:52.200
+<i>Someone in the crowd could be
+the one you need to know,</i>
+
+164
+00:14:52.301 --> 00:14:56.200
+<i>The someone
+who could lift you off the ground</i>
+
+165
+00:14:56.301 --> 00:15:00.000
+<i>Someone in the crowd
+could take you where you wanna go</i>
+
+166
+00:15:00.101 --> 00:15:01.900
+<i>Someone in the crowd
+could make you</i>
+
+167
+00:15:02.001 --> 00:15:03.900
+<i>Someone in the crowd
+could take you</i>
+
+168
+00:15:03.901 --> 00:15:05.500
+<i>flying off the ground</i>
+
+169
+00:15:05.501 --> 00:15:17.000
+<i>If you're the someone
+ready to be found!</i>
+
+170
+00:15:17.301 --> 00:15:19.300
+TOW-AWAY / NO STOPPING
+9pm to 6am / NIGHTLY
+
+171
+00:15:19.301 --> 00:15:21.000
+No.
+
+172
+00:15:21.701 --> 00:15:25.000
+Oh, come on! What...?
+
+173
+00:15:28.101 --> 00:15:30.000
+Ah!
+
+174
+00:15:51.901 --> 00:15:56.000
+STORAGE / ENTRANCE
+
+175
+00:16:49.701 --> 00:16:52.800
+Lipton's / OPEN
+
+176
+00:17:55.601 --> 00:17:57.500
+California oranges
+
+177
+00:18:00.901 --> 00:18:04.400
+VAN BEEK - Tapas & Tunes
+
+178
+00:18:17.601 --> 00:18:19.200
+Please stop sneaking
+into my home.
+
+179
+00:18:19.301 --> 00:18:21.200
+D'you think Mom and Dad
+would call this a "home"?
+
+180
+00:18:21.201 --> 00:18:22.500
+What're you doing?
+
+181
+00:18:22.501 --> 00:18:24.500
+Please don't do that.
+Please don't sit on that.
+
+182
+00:18:24.601 --> 00:18:25.900
+- Are you kidding?
+- Please don't sit on that,
+
+183
+00:18:26.001 --> 00:18:27.400
+don't sit on that.
+Don't sit on that.
+
+184
+00:18:27.501 --> 00:18:29.200
+- Hoagy Carmichael sat on that.
+- Oh my God!
+
+185
+00:18:29.301 --> 00:18:30.700
+The Baked Potato
+just threw it away.
+
+186
+00:18:30.701 --> 00:18:31.800
+I can't imagine why.
+
+187
+00:18:31.801 --> 00:18:34.400
+- And now you're just sitting on it.
+- I got you a throw rug.
+
+188
+00:18:34.401 --> 00:18:35.700
+I don't need that.
+
+189
+00:18:35.701 --> 00:18:38.400
+What if I said
+Miles Davis pissed on it?
+
+190
+00:18:38.401 --> 00:18:40.300
+It's almost insulting.
+
+191
+00:18:40.401 --> 00:18:41.500
+Is it true?
+
+192
+00:18:41.501 --> 00:18:44.100
+When are you going
+to unpack these boxes?!
+
+193
+00:18:44.201 --> 00:18:45.900
+When I unpack them
+in my own club.
+
+194
+00:18:45.901 --> 00:18:46.900
+Oh, Sebastian!
+
+195
+00:18:46.901 --> 00:18:49.500
+It's like a girl broke up
+with you and you're stalking her.
+
+196
+00:18:49.601 --> 00:18:52.000
+You're not still going by there,
+are you?
+
+197
+00:18:52.001 --> 00:18:53.900
+That's...
+
+198
+00:18:54.201 --> 00:18:56.000
+Can't believe it, they turned it
+into a samba-tapas place.
+
+199
+00:18:56.101 --> 00:19:00.000
+- Oh my God, Sebastian!
+- Samba, tapas.
+
+200
+00:19:00.101 --> 00:19:02.600
+Pick one, you know?
+Do one right.
+
+201
+00:19:02.701 --> 00:19:04.600
+I have someone
+I want you to meet.
+
+202
+00:19:04.601 --> 00:19:06.700
+I don't want to meet anyone.
+
+203
+00:19:06.701 --> 00:19:07.500
+No, no,
+I don't want to meet anyone.
+
+204
+00:19:07.601 --> 00:19:08.700
+- Dad gave you this?
+- Yes.
+
+205
+00:19:08.701 --> 00:19:10.000
+You'll like her.
+
+206
+00:19:10.101 --> 00:19:11.700
+I don't think I'm gonna like her.
+
+207
+00:19:11.701 --> 00:19:13.500
+- Does she like jazz?
+- Probably not.
+
+208
+00:19:13.601 --> 00:19:15.000
+Then what are we gonna
+talk about?
+
+209
+00:19:15.101 --> 00:19:16.500
+I dont know! It doesn't matter,
+okay?
+
+210
+00:19:16.601 --> 00:19:19.500
+Because you're living like a hermit.
+You're driving without insurance!
+
+211
+00:19:19.601 --> 00:19:21.100
+- It doesn't matter?
+- Yeah, it doesn't matter.
+
+212
+00:19:21.201 --> 00:19:22.500
+- Okay.
+- You need to get serious.
+
+213
+00:19:22.601 --> 00:19:24.600
+Well, then I know a guy with
+a face tattoo that you should see.
+
+214
+00:19:24.701 --> 00:19:26.400
+- Okay, low blow.
+- With a heart of gold.
+
+215
+00:19:26.501 --> 00:19:28.200
+- Get serious!
+- Get serious? Laura.
+
+216
+00:19:28.301 --> 00:19:31.900
+I... I had a very serious plan
+for my future.
+
+217
+00:19:31.901 --> 00:19:33.000
+I know.
+
+218
+00:19:33.001 --> 00:19:34.400
+It's not my fault
+I got shanghaied!
+
+219
+00:19:34.501 --> 00:19:37.500
+You didn't get shanghaied,
+you got ripped off.
+
+220
+00:19:37.501 --> 00:19:38.800
+What's the difference?
+
+221
+00:19:38.801 --> 00:19:41.900
+I don't know!
+It's not as romantic as that.
+
+222
+00:19:41.901 --> 00:19:43.500
+Don't sit...
+
+223
+00:19:44.201 --> 00:19:47.500
+Everybody knew that guy
+was shady, except for you.
+
+224
+00:19:47.901 --> 00:19:51.400
+Why do you say "romantic"
+like it's a dirty word?
+
+225
+00:19:51.501 --> 00:19:55.500
+Unpaid bills are not romantic.
+Call her.
+
+226
+00:19:55.501 --> 00:19:56.700
+I'm not going to call her.
+
+227
+00:19:56.701 --> 00:20:00.300
+The thing is... y-you're acting like
+life's got me on the ropes.
+
+228
+00:20:00.301 --> 00:20:02.400
+I want to be on the ropes.
+
+229
+00:20:02.401 --> 00:20:04.900
+Okay? I'm just... I'm letting
+life hit me until it gets tired.
+
+230
+00:20:04.901 --> 00:20:05.900
+Oh?
+
+231
+00:20:05.901 --> 00:20:09.500
+Then I'm gonna hit back.
+It's a classic "rope-a-dope".
+
+232
+00:20:09.901 --> 00:20:11.300
+Okay, Ali.
+
+233
+00:20:11.301 --> 00:20:13.200
+I love you.
+Unpack the boxes.
+
+234
+00:20:13.301 --> 00:20:16.400
+- I'm gonna change the locks.
+- You can't afford it.
+
+235
+00:20:17.101 --> 00:20:20.700
+I'm a phoenix
+rising from the ashes!
+
+236
+00:20:24.401 --> 00:20:25.600
+PAST DUE
+
+237
+00:21:07.701 --> 00:21:09.100
+- Hey.
+- Hey Bill.
+
+238
+00:21:09.201 --> 00:21:10.800
+- Thanks for letting me back.
+- You're welcome.
+
+239
+00:21:10.901 --> 00:21:12.500
+I want you to know
+that you're looking at a new man.
+
+240
+00:21:12.501 --> 00:21:13.500
+Good.
+
+241
+00:21:13.501 --> 00:21:15.000
+- A man that's happy to be here.
+- Excellent.
+
+242
+00:21:15.101 --> 00:21:16.600
+- Very-easy-to-work-with man.
+- Okay.
+
+243
+00:21:16.701 --> 00:21:18.300
+And you're gonna...
+play the setlist?
+
+244
+00:21:18.301 --> 00:21:19.800
+Happy to.
+
+245
+00:21:19.801 --> 00:21:21.700
+Even though I don't think
+anybody cares what I play,
+
+246
+00:21:21.801 --> 00:21:23.200
+- but yeah.
+- Yep. Well,
+
+247
+00:21:23.301 --> 00:21:25.500
+if by "anyone" you mean
+anyone other than me,
+
+248
+00:21:25.501 --> 00:21:26.500
+that would be correct.
+
+249
+00:21:26.501 --> 00:21:28.000
+I care, and I don't wanna hear
+the free jazz.
+
+250
+00:21:28.001 --> 00:21:30.300
+Right. Okay.
+
+251
+00:21:30.301 --> 00:21:32.100
+Although I-I... I thought
+that in this town
+
+252
+00:21:32.201 --> 00:21:35.400
+it worked on a sort of "one
+for you, one for me" type system.
+
+253
+00:21:35.801 --> 00:21:38.200
+How about two for you,
+one for me?
+
+254
+00:21:38.601 --> 00:21:40.500
+How 'bout... all for you
+and none for me?
+
+255
+00:21:40.601 --> 00:21:42.000
+- That's perfect. Yes.
+- Great.
+
+256
+00:21:42.101 --> 00:21:43.600
+- Okay.
+- Okay. Mutual decision.
+
+257
+00:21:43.701 --> 00:21:45.700
+- Right. Made-Made by me.
+- Right.
+
+258
+00:21:45.701 --> 00:21:47.500
+And I... signed off on it, so...
+
+259
+00:21:47.501 --> 00:21:50.100
+Whatever. Tell yourself
+what you wanna know.
+
+260
+00:21:50.101 --> 00:21:53.000
+Well, welcome back.
+
+261
+00:21:53.701 --> 00:21:56.400
+There's a nice way
+to say that, Karen.
+
+262
+00:24:59.201 --> 00:25:00.900
+Seb.
+
+263
+00:25:12.801 --> 00:25:14.500
+I do-I-I hear
+what you're saying,
+
+264
+00:25:14.601 --> 00:25:15.800
+but I don't think
+you're saying what you mean.
+
+265
+00:25:15.901 --> 00:25:18.000
+Yeah, I don't think you hear
+what I'm saying. You're fired.
+
+266
+00:25:18.101 --> 00:25:20.100
+Well, I-That's what you're saying,
+but it's not what you mean.
+
+267
+00:25:20.101 --> 00:25:21.100
+What you mean is...
+
+268
+00:25:21.201 --> 00:25:22.300
+You're fired.
+
+269
+00:25:22.401 --> 00:25:24.500
+..."play the setlist".
+
+270
+00:25:24.501 --> 00:25:25.700
+No, I'm saying
+it's too late.
+
+271
+00:25:25.701 --> 00:25:26.900
+It's a warning.
+
+272
+00:25:26.901 --> 00:25:28.300
+What-What planet
+are you from?
+
+273
+00:25:28.401 --> 00:25:29.400
+- Don't fire me.
+- You're done.
+
+274
+00:25:29.501 --> 00:25:31.500
+- Don't fire me.
+- I'm sorry, Seb.
+
+275
+00:25:31.501 --> 00:25:32.800
+It's Christmas.
+
+276
+00:25:32.801 --> 00:25:36.500
+Yeah, I see the decorations.
+Good luck in the New Year.
+
+277
+00:25:49.801 --> 00:25:52.000
+I just heard you play,
+and I wanted to...
+
+278
+00:26:06.501 --> 00:26:09.300
+I don't like the fissure
+on the GT scan.
+
+279
+00:26:09.301 --> 00:26:11.600
+Did you test for achromatopsia?
+
+280
+00:26:11.601 --> 00:26:15.100
+D.O.A. on 23rd. Perp
+laughing his face off at the P.D.
+
+281
+00:26:15.101 --> 00:26:16.700
+Damn Miranda Rights.
+
+282
+00:26:16.801 --> 00:26:18.800
+This is my classroom.
+
+283
+00:26:18.801 --> 00:26:21.000
+You don't like it,
+the door's to my left.
+
+284
+00:26:21.101 --> 00:26:23.900
+Lady, why you be trippin'
+like that?
+
+285
+00:26:23.901 --> 00:26:26.000
+No, Jamal.
+
+286
+00:26:26.401 --> 00:26:29.100
+You be trippin'.
+
+287
+00:26:33.001 --> 00:26:37.500
+SPRING
+
+288
+00:26:37.601 --> 00:26:39.600
+Jump right here!
+
+289
+00:26:41.901 --> 00:26:45.100
+<i>We're talking away</i>
+
+290
+00:26:45.101 --> 00:26:47.800
+<i>I don't know
+what I'm to say,</i>
+
+291
+00:26:47.801 --> 00:26:48.800
+<i>I'll say it anyway</i>
+
+292
+00:26:48.901 --> 00:26:50.200
+Oh. Mia!
+
+293
+00:26:50.201 --> 00:26:52.400
+- Hi!
+- Hi.
+
+294
+00:26:52.501 --> 00:26:54.200
+I want you to meet
+my friend Carlo.
+
+295
+00:26:54.301 --> 00:26:55.600
+- Hi. Carlo.
+- Carlo, this is Mia.
+
+296
+00:26:55.701 --> 00:26:57.100
+- Nice. Mia?
+- Yes, Mia.
+
+297
+00:26:57.201 --> 00:26:59.100
+- Hi. How are you?
+- Carlo is a writer.
+
+298
+00:26:59.201 --> 00:27:01.600
+Yeah. They say I have a knack
+for world-building.
+
+299
+00:27:01.601 --> 00:27:03.100
+I-I got a lot of heat right now.
+
+300
+00:27:03.101 --> 00:27:05.400
+There's been a lot of buzz, people
+talkin' about me, which is exciting.
+
+301
+00:27:05.501 --> 00:27:07.000
+I mean, you work so hard,
+and then all that validation.
+
+302
+00:27:07.101 --> 00:27:08.100
+- It's great...
+- I'm gonna grab a drink.
+
+303
+00:27:08.201 --> 00:27:09.200
+- Yeah.
+- Okay.
+
+304
+00:27:09.301 --> 00:27:10.600
+- Okay.
+- It's really nice to meet you...
+
+305
+00:27:10.701 --> 00:27:21.300
+<i>I'll be gone
+in a day or two</i>
+
+306
+00:27:21.401 --> 00:27:26.300
+<i>So needless to say
+I'm odds and ends,</i>
+
+307
+00:27:26.301 --> 00:27:30.300
+<i>But I'll be stumbling away,</i>
+
+308
+00:27:30.301 --> 00:27:33.500
+<i>Slowly learning
+that life is okay</i>
+
+309
+00:27:33.501 --> 00:27:36.200
+<i>Say after me:</i>
+
+310
+00:27:36.201 --> 00:27:38.900
+<i>"It's no better to be safe
+than sorry"</i>
+
+311
+00:27:38.901 --> 00:27:44.500
+<i>Take on me (Take on me)</i>
+
+312
+00:27:44.601 --> 00:27:50.200
+<i>Take me on (Take on me)</i>
+
+313
+00:27:50.201 --> 00:28:01.300
+<i>I'll be gone
+in a day or two</i>
+
+314
+00:28:01.301 --> 00:28:02.500
+Thank you.
+
+315
+00:28:02.601 --> 00:28:05.000
+Any other requests?!
+
+316
+00:28:07.401 --> 00:28:08.900
+Girl in the front!
+
+317
+00:28:09.001 --> 00:28:10.000
+"I Ran".
+
+318
+00:28:10.001 --> 00:28:13.600
+"I Ran".
+A fantastic suggestion!
+
+319
+00:28:13.701 --> 00:28:16.900
+All right, piano man,
+tickle those ivories. Let's hit it.
+
+320
+00:28:16.901 --> 00:28:19.600
+One, two, three, four!
+
+321
+00:28:25.901 --> 00:28:27.200
+Uh!
+
+322
+00:28:30.001 --> 00:28:31.500
+That's right!
+
+323
+00:28:31.601 --> 00:28:34.800
+<i>I walk alone the avenue</i>
+
+324
+00:28:34.801 --> 00:28:39.500
+<i>I never thought I'd meet
+a girl like you</i>
+
+325
+00:28:39.501 --> 00:28:42.000
+<i>Meet a girl like you</i>
+
+326
+00:28:42.101 --> 00:28:43.800
+(Me?)
+
+327
+00:28:44.501 --> 00:28:47.700
+<i>With auburn hair
+and tawny eyes,</i>
+
+328
+00:28:47.801 --> 00:28:52.200
+<i>With kind of eyes
+that hypnotize me through</i>
+
+329
+00:28:52.201 --> 00:28:56.400
+<i>That hypnotize me through</i>
+
+330
+00:28:56.401 --> 00:29:02.300
+<i>And I ran,
+I ran so far away</i>
+
+331
+00:29:02.301 --> 00:29:04.900
+<i>I couldn't get away</i>
+
+332
+00:29:15.201 --> 00:29:21.200
+<i>Sometimes I feel
+I've got to run away,</i>
+
+333
+00:29:21.201 --> 00:29:24.500
+<i>I've got to get away</i>
+
+334
+00:29:24.501 --> 00:29:29.800
+<i>From the pain you drive
+into the heart of me</i>
+
+335
+00:29:29.801 --> 00:29:31.800
+All right. I remember you.
+
+336
+00:29:31.801 --> 00:29:34.600
+And I'll admit I was
+a little curt that night.
+
+337
+00:29:34.701 --> 00:29:36.500
+- "Curt"?
+- Okay, I was an asshole.
+
+338
+00:29:36.601 --> 00:29:38.400
+- I can admit that.
+- Okay.
+
+339
+00:29:38.501 --> 00:29:41.000
+But requesting "I Ran"
+from a serious musician
+
+340
+00:29:41.001 --> 00:29:42.200
+is just... it's too far.
+
+341
+00:29:42.201 --> 00:29:45.800
+My Lord! Did you just say
+"a serious musician"?
+
+342
+00:29:45.801 --> 00:29:46.800
+I don't think so.
+
+343
+00:29:46.801 --> 00:29:48.400
+- Can I borrow what you're wearing?
+- Why?
+
+344
+00:29:48.501 --> 00:29:49.700
+'Cause I have an audition
+next week.
+
+345
+00:29:49.801 --> 00:29:51.800
+I'm playing
+a serious firefighter.
+
+346
+00:29:51.801 --> 00:29:53.000
+So you're an actress.
+
+347
+00:29:53.001 --> 00:29:55.600
+I thought you looked familiar.
+Have I seen you on anything?
+
+348
+00:29:55.701 --> 00:29:58.900
+Uh... A coffee shop?
+On the Warner Bros. lot?
+
+349
+00:29:59.001 --> 00:30:00.600
+- That's classic.
+- Oh, I see.
+
+350
+00:30:00.701 --> 00:30:01.800
+- Yeah.
+- You're a barista.
+
+351
+00:30:01.901 --> 00:30:04.000
+And I can see how you could then
+look down on me
+
+352
+00:30:04.001 --> 00:30:05.200
+from all the way up there.
+
+353
+00:30:05.301 --> 00:30:07.200
+Time to do the next set.
+
+354
+00:30:08.301 --> 00:30:10.100
+He doesn't... I don't...
+
+355
+00:30:10.401 --> 00:30:11.900
+He doesn't tell me
+what to do.
+
+356
+00:30:12.001 --> 00:30:13.400
+He just... told you
+what to do...
+
+357
+00:30:13.401 --> 00:30:15.500
+I know, he... I let him.
+
+358
+00:30:15.501 --> 00:30:16.900
+- What's your name?
+- Mia.
+
+359
+00:30:16.901 --> 00:30:18.400
+Mia.
+
+360
+00:30:19.501 --> 00:30:21.800
+Guess I'll see you
+in the movies.
+
+361
+00:30:23.801 --> 00:30:25.600
+- Heard of Joseph Campbell?
+- Uh, yeah.
+
+362
+00:30:25.701 --> 00:30:27.200
+I have this idea
+to do a re-imagining
+
+363
+00:30:27.301 --> 00:30:30.000
+of "Goldilocks and the Three Bears"
+but from the perspective of the bears.
+
+364
+00:30:30.101 --> 00:30:32.200
+It's kind of thrilling.
+Yeah, it could be like a franchise.
+
+365
+00:30:32.301 --> 00:30:33.300
+- Right.
+- So we don't know.
+
+366
+00:30:33.401 --> 00:30:34.900
+There could've been a fourth bear,
+we don't know.
+
+367
+00:30:34.901 --> 00:30:36.800
+George Michael!
+
+368
+00:30:42.001 --> 00:30:43.000
+Hello.
+
+369
+00:30:43.001 --> 00:30:43.900
+- Sorry.
+- Yeah, yeah.
+
+370
+00:30:43.901 --> 00:30:45.300
+It's... I know that guy.
+
+371
+00:30:45.401 --> 00:30:47.500
+Did you get your keys?
+
+372
+00:30:49.001 --> 00:30:50.400
+Mm-hmm. Yes.
+
+373
+00:30:50.501 --> 00:30:52.200
+Can you grab mine?
+
+374
+00:30:52.301 --> 00:30:53.300
+Can I what?
+
+375
+00:30:53.301 --> 00:30:54.500
+Would you be able to grab mine?
+My keys?
+
+376
+00:30:54.601 --> 00:30:55.600
+- I can't hear you.
+- Sorry.
+
+377
+00:30:55.701 --> 00:30:58.700
+- Can-Can you grab my keys?
+- Oh.
+
+378
+00:30:58.801 --> 00:31:00.000
+- Please?
+- Oh, there we go.
+
+379
+00:31:00.101 --> 00:31:02.400
+- Thank you.
+- You're welcome.
+
+380
+00:31:04.101 --> 00:31:06.700
+- What kind?
+- It's a Prius.
+
+381
+00:31:08.501 --> 00:31:10.300
+That mean the...
+That does't help me.
+
+382
+00:31:10.301 --> 00:31:12.100
+With a green ribbon.
+
+383
+00:31:12.201 --> 00:31:13.600
+All right.
+
+384
+00:31:15.601 --> 00:31:18.700
+Those look, uh, comfortable.
+
+385
+00:31:18.801 --> 00:31:20.600
+They are.
+
+386
+00:31:21.401 --> 00:31:24.200
+Thank you for saving the day
+back there.
+
+387
+00:31:25.801 --> 00:31:29.300
+Well, you didn't really give me
+much of a choice.
+
+388
+00:31:29.401 --> 00:31:32.700
+It's pretty strange that we keep
+running into each other.
+
+389
+00:31:32.801 --> 00:31:36.700
+It is strange.
+Maybe it means something.
+
+390
+00:31:36.801 --> 00:31:38.100
+- I doubt it.
+- Yeah, I don't think so.
+
+391
+00:31:38.101 --> 00:31:40.000
+Where's my car?!
+
+392
+00:31:40.401 --> 00:31:42.500
+You gotta put that thing
+to your chin.
+
+393
+00:31:42.601 --> 00:31:44.600
+- This?
+- Yeah.
+
+394
+00:31:45.001 --> 00:31:46.700
+Yeah, it makes your head
+into an antenna, so...
+
+395
+00:31:46.701 --> 00:31:47.700
+Oh?
+
+396
+00:31:47.701 --> 00:31:49.300
+I think it gives you cancer,
+but you find your car faster.
+
+397
+00:31:49.301 --> 00:31:50.300
+What?
+
+398
+00:31:50.301 --> 00:31:52.100
+I mean, you don't live as long,
+but you get where you're going quicker,
+
+399
+00:31:52.201 --> 00:31:54.300
+- so it all evens out.
+- That sounds terrible.
+
+400
+00:31:54.401 --> 00:31:56.900
+- Just a suggestion.
+- You're a...
+
+401
+00:31:57.201 --> 00:31:59.200
+You're a real, uh...
+
+402
+00:31:59.201 --> 00:32:01.400
+- What's the word am I looking for?
+- Knight in shining armor?
+
+403
+00:32:01.501 --> 00:32:05.100
+- Weirdo. That was the word.
+- Okay.
+
+404
+00:32:11.501 --> 00:32:13.700
+Not much to look at, huh?
+
+405
+00:32:14.001 --> 00:32:15.900
+I've seen better.
+
+406
+00:32:23.401 --> 00:32:27.500
+<i>The sun is nearly gone,</i>
+
+407
+00:32:27.601 --> 00:32:32.400
+<i>The lights are turnin' on,</i>
+
+408
+00:32:32.401 --> 00:32:39.000
+<i>A silver shine
+that stretches to the sea</i>
+
+409
+00:32:40.301 --> 00:32:43.300
+<i>We've stumbled on a view</i>
+
+410
+00:32:43.401 --> 00:32:48.800
+<i>That's tailor-made for two</i>
+
+411
+00:32:48.801 --> 00:32:54.700
+<i>What a shame those two
+are you and me</i>
+
+412
+00:32:55.701 --> 00:33:00.500
+<i>Some other girl and guy</i>
+
+413
+00:33:00.601 --> 00:33:03.400
+<i>Would love this swirling sky,</i>
+
+414
+00:33:03.501 --> 00:33:07.600
+<i>But there's only you and I</i>
+
+415
+00:33:07.701 --> 00:33:11.400
+<i>And we've got no shot</i>
+
+416
+00:33:11.501 --> 00:33:14.800
+<i>This could never be</i>
+
+417
+00:33:14.801 --> 00:33:17.700
+<i>- You're not the type for me
+- Really?</i>
+
+418
+00:33:17.801 --> 00:33:22.100
+<i>And there's not a spark
+in sight</i>
+
+419
+00:33:22.201 --> 00:33:27.800
+<i>What a waste
+of a lovely night</i>
+
+420
+00:33:29.001 --> 00:33:30.700
+<i>You say
+there's nothing here?</i>
+
+421
+00:33:30.701 --> 00:33:32.500
+<i>Well, let's make something clear</i>
+
+422
+00:33:32.501 --> 00:33:35.100
+<i>I think I'll be the one
+to make that call</i>
+
+423
+00:33:35.101 --> 00:33:36.100
+But you'll call?
+
+424
+00:33:36.101 --> 00:33:38.800
+<i>And though you looked so cute
+in your polyester suit,</i>
+
+425
+00:33:38.801 --> 00:33:39.800
+It's wool.
+
+426
+00:33:39.801 --> 00:33:42.500
+<i>You're right,
+I'd never fall for you at all</i>
+
+427
+00:33:42.501 --> 00:33:45.800
+<i>And maybe this appeals</i>
+
+428
+00:33:45.901 --> 00:33:48.700
+<i>To someone not in heels</i>
+
+429
+00:33:48.801 --> 00:33:52.800
+<i>Or to any girl who feels</i>
+
+430
+00:33:52.801 --> 00:33:56.300
+<i>There's some chance
+for romance</i>
+
+431
+00:33:56.401 --> 00:33:59.000
+<i>But, I'm frankly
+feeling nothing</i>
+
+432
+00:33:59.001 --> 00:34:00.200
+<i>Is that so?</i>
+
+433
+00:34:00.201 --> 00:34:02.100
+<i>Or it could be
+less than nothing</i>
+
+434
+00:34:02.201 --> 00:34:05.000
+<i>Good to know,
+so you agree?</i>
+
+435
+00:34:05.001 --> 00:34:06.300
+<i>That's right</i>
+
+436
+00:34:06.301 --> 00:34:10.600
+<i>What a waste
+of a lovely night</i>
+
+437
+00:36:17.600 --> 00:36:19.300
+Ah.
+
+438
+00:36:19.401 --> 00:36:21.000
+Hi, Greg.
+
+439
+00:36:21.301 --> 00:36:23.400
+Hi... Oh! Sorry, I'm late.
+
+440
+00:36:23.401 --> 00:36:26.600
+Yeah. I'll be there soon.
+Okay, bye.
+
+441
+00:36:46.501 --> 00:36:49.100
+- It's... It's just right there.
+- Just right here.
+
+442
+00:36:49.101 --> 00:36:50.600
+Hmm.
+
+443
+00:36:54.501 --> 00:36:56.500
+Do you want a ride
+to your car?
+
+444
+00:36:57.301 --> 00:36:59.700
+No, I'm just... right up here.
+
+445
+00:37:02.001 --> 00:37:03.800
+Good night.
+
+446
+00:37:09.701 --> 00:37:11.100
+Good night.
+
+447
+00:38:23.501 --> 00:38:26.800
+Excuse me.
+This is gluten-free, right?
+
+448
+00:38:27.201 --> 00:38:28.200
+No.
+
+449
+00:38:28.301 --> 00:38:29.300
+What?!
+
+450
+00:38:29.401 --> 00:38:30.400
+Mm-mmm.
+
+451
+00:38:30.501 --> 00:38:32.800
+What? I'd like a refund.
+
+452
+00:38:34.101 --> 00:38:37.300
+Okay. Let me check on that for you.
+
+453
+00:38:38.101 --> 00:38:41.700
+Mia? You're closing friday.
+
+454
+00:38:41.701 --> 00:38:44.600
+I-I c-I can't close on friday.
+I have an audition, remember?
+
+455
+00:38:44.701 --> 00:38:46.900
+Do I look like I care?
+Reschedule it.
+
+456
+00:38:47.001 --> 00:38:48.600
+- Oh, and, uh, we need to have
+- I...
+
+457
+00:38:48.601 --> 00:38:50.200
+a little talk tomorrow, okay?
+
+458
+00:38:50.201 --> 00:38:53.900
+- Fix your apron, please.
+- Uh... Okay.
+
+459
+00:38:58.001 --> 00:38:59.700
+You again!
+
+460
+00:39:01.601 --> 00:39:02.600
+What're you doin' here?
+
+461
+00:39:02.601 --> 00:39:06.200
+Oh, you know, just meetings
+and... studio heads and...
+
+462
+00:39:06.201 --> 00:39:08.000
+How'd you get on the lot?
+
+463
+00:39:08.001 --> 00:39:10.700
+I basically just hauled ass
+past the guard gates, so...
+
+464
+00:39:10.801 --> 00:39:13.600
+I think I have 20 minutes
+until they find me.
+
+465
+00:39:13.701 --> 00:39:15.500
+You don't have a break...
+coming up, do you?
+
+466
+00:39:15.501 --> 00:39:17.400
+I'm off in 10 minutes. So...
+
+467
+00:39:18.701 --> 00:39:20.300
+Can I hide in the bathroom?
+
+468
+00:39:20.301 --> 00:39:22.000
+- Yes.
+- Okay. (Thank you.)
+
+469
+00:39:23.601 --> 00:39:24.700
+Sorry.
+
+470
+00:39:24.801 --> 00:39:26.200
+Uh...
+
+471
+00:39:26.201 --> 00:39:28.600
+I actually do have to check.
+I'm... sorry.
+
+472
+00:39:32.101 --> 00:39:33.900
+That's the window
+that Humphrey Bogart
+
+473
+00:39:34.001 --> 00:39:35.800
+and Ingrid Bergman
+looked out of in Casablanca.
+
+474
+00:39:35.901 --> 00:39:37.100
+- Wow!
+- Yeah.
+
+475
+00:39:37.201 --> 00:39:39.100
+I can't believe you work
+right across the street from that.
+
+476
+00:39:39.201 --> 00:39:41.000
+- Yeah.
+- That's amazing.
+
+477
+00:39:41.101 --> 00:39:44.700
+What was your, uh...,
+your Bogart's name?
+
+478
+00:39:45.001 --> 00:39:47.200
+What's his name?
+Is it Greg?
+
+479
+00:39:47.201 --> 00:39:49.300
+Yeah. Greg.
+
+480
+00:39:49.301 --> 00:39:52.000
+Right. How long
+have you, uh, been...?
+
+481
+00:39:52.101 --> 00:39:54.100
+We've been seeing each other
+for about a month.
+
+482
+00:39:54.101 --> 00:39:55.400
+Uh, that's great.
+
+483
+00:39:55.501 --> 00:39:57.100
+He's, uh... He's sweet.
+
+484
+00:39:57.101 --> 00:39:59.200
+Anyway, I love being around
+this stuff, you know?
+
+485
+00:39:59.301 --> 00:40:01.700
+I know what you mean. I-I get coffee
+5 miles out of the way
+
+486
+00:40:01.801 --> 00:40:04.400
+- just so I can be near a jazz club.
+- Really?
+
+487
+00:40:04.501 --> 00:40:05.800
+Yeah, the Van Beek.
+Do you know it?
+
+488
+00:40:05.801 --> 00:40:06.800
+Mm-mmm.
+
+489
+00:40:06.801 --> 00:40:08.200
+All the big swing bands
+used to play there.
+
+490
+00:40:08.201 --> 00:40:10.300
+Count Basie, Chick Webb.
+
+491
+00:40:11.001 --> 00:40:14.200
+Anyway, it's a samba-tapas place
+now, so...
+
+492
+00:40:14.901 --> 00:40:16.100
+What's a samba-tapas place?
+
+493
+00:40:16.101 --> 00:40:18.400
+You know, it's like a samba place
+where they serve tapas.
+
+494
+00:40:18.501 --> 00:40:19.500
+- Oh.
+- Yeah.
+
+495
+00:40:19.501 --> 00:40:22.000
+So the joke's on... history?
+
+496
+00:40:22.001 --> 00:40:23.800
+I don't know. That's L.A.
+They just...
+
+497
+00:40:23.901 --> 00:40:27.300
+They-They-They worship everything
+and they value nothing.
+
+498
+00:40:27.401 --> 00:40:30.100
+We're about to roll.
+Stop, please, guys.
+
+499
+00:40:31.001 --> 00:40:32.300
+- You're rolling?
+- Yeah.
+
+500
+00:40:32.401 --> 00:40:33.400
+- Yeah.
+- I know.
+
+501
+00:40:33.501 --> 00:40:35.300
+They shoot movies on my street
+all the time, so I know about movies.
+
+502
+00:40:35.401 --> 00:40:36.400
+- Come this way.
+- Right.
+
+503
+00:40:36.401 --> 00:40:37.900
+It's a lock-down.
+
+504
+00:40:38.701 --> 00:40:40.000
+- I love her!
+- And here we go.
+
+505
+00:40:40.101 --> 00:40:42.500
+So... Hey, Mia.
+How did you get into this?
+
+506
+00:40:42.601 --> 00:40:44.400
+- And... roll!
+- Get into what?
+
+507
+00:40:44.401 --> 00:40:45.700
+Sound speed!
+
+508
+00:40:45.701 --> 00:40:48.100
+- You know, movies and acting.
+- Action.
+
+509
+00:40:48.101 --> 00:40:49.700
+Oh.
+
+510
+00:40:49.701 --> 00:40:52.100
+- My aunt was an actress.
+- Oh, okay.
+
+511
+00:40:52.401 --> 00:40:54.700
+She was in a traveling
+theater company.
+
+512
+00:40:54.801 --> 00:40:57.100
+I grew up in Boulder City,
+Nevada.
+
+513
+00:40:57.201 --> 00:40:59.800
+So across the street from my house
+there was this little library,
+
+514
+00:40:59.801 --> 00:41:01.300
+that had an old movies section.
+
+515
+00:41:01.301 --> 00:41:04.600
+And so she... she took me
+and we spent an entire day
+
+516
+00:41:04.601 --> 00:41:06.100
+watching all these old movies
+
+517
+00:41:06.101 --> 00:41:10.800
+like "Notorious" and... "Bringing Up
+Baby", "Casablanca"... and...
+
+518
+00:41:10.901 --> 00:41:12.800
+- Cut it there. Cut!
+- Check the gate.
+
+519
+00:41:12.901 --> 00:41:14.700
+- We can talk now.
+- She sounds incredible.
+
+520
+00:41:14.701 --> 00:41:15.700
+She was incredible.
+
+521
+00:41:15.701 --> 00:41:18.200
+And I would put on all these plays
+in my bedroom...
+
+522
+00:41:18.301 --> 00:41:20.900
+and... it would basically just be
+she and I...
+
+523
+00:41:21.001 --> 00:41:23.700
+re-enacting those scenes
+from the movies.
+
+524
+00:41:23.801 --> 00:41:25.400
+And then I would write
+my own plays.
+
+525
+00:41:25.501 --> 00:41:27.200
+- Wow.
+- Uh... Yeah.
+
+526
+00:41:47.901 --> 00:41:49.800
+I love it.
+
+527
+00:41:53.501 --> 00:41:56.500
+So anyway, I left college
+after two years to come here.
+
+528
+00:41:56.601 --> 00:41:59.400
+And, uh, my last audition
+was for a teen soap
+
+529
+00:41:59.501 --> 00:42:01.900
+pitched as Dangerous Minds
+meets The O.C.
+
+530
+00:42:01.901 --> 00:42:03.800
+So, yeah...,
+
+531
+00:42:04.101 --> 00:42:06.100
+should've been a lawyer.
+
+532
+00:42:06.101 --> 00:42:08.800
+'Cause the world needs
+more lawyers...
+
+533
+00:42:08.801 --> 00:42:10.400
+It doesn't need more actresses.
+
+534
+00:42:10.501 --> 00:42:12.000
+You're not just an actress.
+
+535
+00:42:12.001 --> 00:42:13.200
+What do you mean
+"just an actress"?
+
+536
+00:42:13.301 --> 00:42:14.700
+You said it yourself,
+you were a...
+
+537
+00:42:14.801 --> 00:42:16.800
+y-you were a child prodigy
+playwright.
+
+538
+00:42:16.801 --> 00:42:18.400
+That is not what I said.
+
+539
+00:42:18.401 --> 00:42:21.800
+Well, you're too modest
+to say it, but it's true.
+
+540
+00:42:21.901 --> 00:42:23.800
+So you could just write
+your own roles, you know?
+
+541
+00:42:23.901 --> 00:42:25.800
+Write something that's
+as interesting as you are,
+
+542
+00:42:25.901 --> 00:42:27.300
+and you don't have to audition
+for this...
+
+543
+00:42:27.401 --> 00:42:28.800
+- Y-Yeah.
+- uh, pishi kaka.
+
+544
+00:42:28.901 --> 00:42:30.200
+Look at Louis Armstrong,
+you know?
+
+545
+00:42:30.301 --> 00:42:32.100
+He could have just played
+the marching band charts
+
+546
+00:42:32.101 --> 00:42:33.000
+that he was given.
+
+547
+00:42:33.001 --> 00:42:34.900
+But he didn't do it.
+What did he do?
+
+548
+00:42:35.001 --> 00:42:37.900
+- What did he do?
+- Well, he made history, didn't he?
+
+549
+00:42:38.201 --> 00:42:39.700
+Well, I'm gonna stop
+auditioning
+
+550
+00:42:39.801 --> 00:42:42.200
+and I'm gonna make history
+instead.
+
+551
+00:42:42.201 --> 00:42:45.000
+Well, my work is done here.
+
+552
+00:42:46.001 --> 00:42:48.000
+I should probably tell you
+something now.
+
+553
+00:42:48.101 --> 00:42:49.700
+- Just to get it out the way.
+- Mm-hmm.
+
+554
+00:42:49.701 --> 00:42:51.800
+I hate jazz.
+
+555
+00:42:53.301 --> 00:42:54.300
+You okay?
+
+556
+00:42:54.301 --> 00:42:56.600
+What do you mean
+you hate jazz?
+
+557
+00:42:56.701 --> 00:42:58.500
+It just means that when
+I listen to it, I don't like it.
+
+558
+00:42:58.601 --> 00:43:01.700
+Yeah, but it's just a blanket statement
+that you don't like jazz.
+
+559
+00:43:01.701 --> 00:43:03.800
+What are you doing right now?
+
+560
+00:43:04.501 --> 00:43:06.100
+Nothing.
+
+561
+00:43:22.601 --> 00:43:26.000
+You know, I just think that people,
+when they say that they...,
+
+562
+00:43:26.301 --> 00:43:28.500
+you know, "I hate jazz"...,
+
+563
+00:43:29.201 --> 00:43:31.700
+they just...
+they don't... have context.
+
+564
+00:43:31.801 --> 00:43:33.900
+They don't know
+where it comes from, you know?
+
+565
+00:43:34.001 --> 00:43:37.600
+Jazz was born in a little...
+flophouse in New Orleans,
+
+566
+00:43:37.701 --> 00:43:39.900
+and then just because people
+were crammed in there,
+
+567
+00:43:40.001 --> 00:43:41.200
+they spoke
+five different languages,
+
+568
+00:43:41.301 --> 00:43:42.400
+they couldn't
+talk to each other.
+
+569
+00:43:42.501 --> 00:43:46.100
+The only way that they could
+communicate... was with jazz.
+
+570
+00:43:46.101 --> 00:43:48.700
+Yeah, well, what about Kenny G?
+
+571
+00:43:49.101 --> 00:43:50.800
+- What?
+- What about Kenny G?
+
+572
+00:43:50.901 --> 00:43:53.300
+I mean, what about elevator music?
+You know?
+
+573
+00:43:53.401 --> 00:43:56.200
+- Jazz music that I know.
+- What about it?
+
+574
+00:43:56.301 --> 00:43:57.400
+- From my life.
+- Mm-hmm.
+
+575
+00:43:57.501 --> 00:43:59.800
+I just...
+I mean, I-I find it relaxing.
+
+576
+00:43:59.901 --> 00:44:02.300
+It's not relaxing.
+It's not! It's not.
+
+577
+00:44:02.301 --> 00:44:03.800
+Sidney Bechet shot somebody
+
+578
+00:44:03.801 --> 00:44:05.400
+because they told him
+he played a wrong note.
+
+579
+00:44:05.401 --> 00:44:06.800
+That's hardly relaxing.
+
+580
+00:44:06.901 --> 00:44:08.000
+Yeah, but where I grew up
+
+581
+00:44:08.001 --> 00:44:10.900
+there was this station
+called KJAZZ 103.
+
+582
+00:44:11.001 --> 00:44:12.900
+And people
+would just put on that station
+
+583
+00:44:13.001 --> 00:44:14.400
+when they had
+a cocktail party...
+
+584
+00:44:14.401 --> 00:44:15.400
+Right.
+
+585
+00:44:15.401 --> 00:44:17.700
+And everyone would kind of just talk
+over it.
+
+586
+00:44:17.801 --> 00:44:19.100
+- I know.
+- 'Cause it was...
+
+587
+00:44:19.201 --> 00:44:20.700
+- That's the pro... Okay. O-kay.
+- It's...
+
+588
+00:44:20.801 --> 00:44:22.300
+So I think that
+that's part of the problem,
+
+589
+00:44:22.401 --> 00:44:23.400
+is that you can't hear it,
+you know?
+
+590
+00:44:23.501 --> 00:44:25.800
+You have to see it, you have
+to see... what's at stake.
+
+591
+00:44:25.801 --> 00:44:26.900
+I mean, look at these fellas.
+
+592
+00:44:26.901 --> 00:44:29.100
+Look at... Look at the...
+the-the sax player right now.
+
+593
+00:44:29.201 --> 00:44:31.300
+He just hijacked the song.
+He's on his own trail.
+
+594
+00:44:31.401 --> 00:44:33.800
+Everyone of these guys
+are composing, rearranging,
+
+595
+00:44:33.901 --> 00:44:35.800
+they're writing...
+and they're playing the melody.
+
+596
+00:44:35.901 --> 00:44:38.100
+They're just...
+And now look, the trumpet player.
+
+597
+00:44:38.201 --> 00:44:40.000
+He's got his own idea.
+And so...
+
+598
+00:44:40.101 --> 00:44:43.900
+it's conflict, and it's compromise,
+and it's just...
+
+599
+00:44:44.001 --> 00:44:47.000
+It's new every time.
+It's brand new every night.
+
+600
+00:44:47.001 --> 00:44:50.000
+It's very, very exciting.
+
+601
+00:44:56.201 --> 00:44:58.000
+And it's dying.
+
+602
+00:44:58.001 --> 00:45:01.000
+It's dying, Mia,
+it's dying on the vine.
+
+603
+00:45:01.101 --> 00:45:04.600
+And the world says:
+"Let it die. It had its time."
+
+604
+00:45:04.601 --> 00:45:07.000
+Well, not on my watch.
+
+605
+00:45:07.801 --> 00:45:09.000
+What are you gonna do?
+
+606
+00:45:09.201 --> 00:45:11.400
+I'll have my own club.
+
+607
+00:45:11.401 --> 00:45:12.900
+- Really?
+- Yes.
+
+608
+00:45:13.001 --> 00:45:14.700
+We're gonna play
+whatever we want,
+
+609
+00:45:14.801 --> 00:45:17.000
+whenever we want,
+however we want,
+
+610
+00:45:17.001 --> 00:45:20.900
+as long as it's pure jazz.
+
+611
+00:45:21.201 --> 00:45:23.200
+Hi, this is Mia Dolan.
+
+612
+00:45:23.301 --> 00:45:25.900
+Yeah, I just missed a call.
+
+613
+00:45:32.201 --> 00:45:34.500
+- I got a callback.
+- What?!
+
+614
+00:45:34.501 --> 00:45:36.600
+Come on! For what?!
+
+615
+00:45:36.601 --> 00:45:40.000
+For a TV show! The one
+I was telling you about. Really.
+
+616
+00:45:40.101 --> 00:45:41.500
+The Dangerous Minds
+meets The O.C.?
+
+617
+00:45:41.501 --> 00:45:42.500
+Yeah.
+
+618
+00:45:42.501 --> 00:45:44.200
+- Congratulations! That's incredible.
+- It's really exciting.
+
+619
+00:45:44.301 --> 00:45:46.300
+I feel like I said negative stuff
+about it before.
+
+620
+00:45:46.301 --> 00:45:47.300
+What?
+
+621
+00:45:47.301 --> 00:45:49.400
+It's like "Rebel Without a Cause"
+sort of.
+
+622
+00:45:49.401 --> 00:45:51.700
+"I got the bullets!"
+
+623
+00:45:51.801 --> 00:45:53.600
+Yes.
+
+624
+00:45:54.301 --> 00:45:56.100
+- You've never seen it!
+- I've never seen it.
+
+625
+00:45:56.201 --> 00:45:58.800
+Oh my. You know,
+it's playing in the Rialto.
+
+626
+00:45:58.901 --> 00:46:00.100
+- Really?
+- Yes.
+
+627
+00:46:00.201 --> 00:46:04.000
+You should go... I mean, I...
+I'll go-I'll go-I can take you.
+
+628
+00:46:04.101 --> 00:46:05.500
+- Okay.
+- You know, for research.
+
+629
+00:46:05.601 --> 00:46:06.600
+- For research.
+- Yeah.
+
+630
+00:46:06.701 --> 00:46:07.900
+- Yeah.
+- Okay.
+
+631
+00:46:08.001 --> 00:46:10.400
+Uh, monday night,
+ten-ten o'clock.
+
+632
+00:46:10.501 --> 00:46:12.300
+- Yeah! Great!
+- Okay!
+
+633
+00:46:12.301 --> 00:46:13.800
+For research.
+
+634
+00:46:56.301 --> 00:46:59.200
+<i>City of stars,</i>
+
+635
+00:46:59.201 --> 00:47:04.800
+<i>Are you shining
+just for me?</i>
+
+636
+00:47:06.201 --> 00:47:09.200
+<i>City of stars,</i>
+
+637
+00:47:09.201 --> 00:47:14.700
+<i>There's so much
+that I can't see</i>
+
+638
+00:47:15.301 --> 00:47:18.600
+<i>Who knows?</i>
+
+639
+00:47:18.601 --> 00:47:25.000
+<i>Is this the start
+of something wonderful and new?</i>
+
+640
+00:47:25.301 --> 00:47:35.000
+<i>Or one more dream
+that I cannot make true?</i>
+
+641
+00:48:01.101 --> 00:48:03.800
+- Stand right there, please.
+- Okay. Nice to meet you.
+
+642
+00:48:05.901 --> 00:48:09.000
+- (Hi.)
+- Hi.
+
+643
+00:48:31.601 --> 00:48:34.500
+- In your own time.
+- Okay.
+
+644
+00:48:38.101 --> 00:48:39.500
+Two options:
+
+645
+00:48:39.501 --> 00:48:42.400
+you either follow my rules
+or follow my rules. Capisce?
+
+646
+00:48:42.401 --> 00:48:43.900
+Thank you.
+
+647
+00:48:43.901 --> 00:48:46.000
+- It's... Oh.
+- Thanks.
+
+648
+00:48:46.001 --> 00:48:47.100
+I can do it a different way.
+
+649
+00:48:47.101 --> 00:48:50.100
+No, that's-that's fine.
+Thank you very much. Thank you.
+
+650
+00:48:57.901 --> 00:49:00.300
+- That was fun. Thanks.
+- Bye.
+
+651
+00:49:11.501 --> 00:49:13.500
+RIALTO / REBEL WITHOUT A CASE
+
+652
+00:49:30.001 --> 00:49:31.400
+Hey, Mia.
+
+653
+00:49:31.701 --> 00:49:33.700
+- What?
+- Greg's here.
+
+654
+00:49:33.701 --> 00:49:34.800
+What do you m...?
+
+655
+00:49:34.801 --> 00:49:37.800
+Hey, babe.
+Got a space out front.
+
+656
+00:49:38.201 --> 00:49:39.500
+- Great!
+- We should get going.
+
+657
+00:49:39.601 --> 00:49:42.000
+- Ok...
+- My brother landed really early.
+
+658
+00:49:44.201 --> 00:49:45.200
+Did you forget?
+
+659
+00:49:45.201 --> 00:49:47.100
+- Shit.
+- You forgot.
+
+660
+00:49:47.101 --> 00:49:48.500
+That's tonight...
+
+661
+00:49:48.501 --> 00:49:49.700
+- That's okay.
+- Yeah.
+
+662
+00:49:49.801 --> 00:49:51.100
+- Yeah. You forgot.
+- Okay. All right.
+
+663
+00:49:51.101 --> 00:49:52.700
+So then I'll just get changed.
+
+664
+00:49:52.701 --> 00:49:53.700
+- Okay.
+- Okay.
+
+665
+00:49:53.801 --> 00:49:55.100
+- Great.
+- Great.
+
+666
+00:49:57.601 --> 00:49:58.900
+- Yeah, that's him.
+- Uh...
+
+667
+00:49:58.901 --> 00:50:00.700
+Hey, Josh. Yeah. Uh...
+
+668
+00:50:00.701 --> 00:50:04.300
+Uh, just picking up Mia.
+We'll be there in like, uh...
+
+669
+00:50:04.901 --> 00:50:06.800
+But now we got
+this surround-sound set-up.
+
+670
+00:50:06.901 --> 00:50:09.100
+Oh, it's like being
+in a movie theater.
+
+671
+00:50:09.101 --> 00:50:10.100
+Wow.
+
+672
+00:50:10.101 --> 00:50:12.100
+Well, better than being
+in a theater, really.
+
+673
+00:50:12.201 --> 00:50:13.300
+And you know theaters
+these days.
+
+674
+00:50:13.401 --> 00:50:15.100
+- Yeah.
+- They're so dirty.
+
+675
+00:50:15.201 --> 00:50:16.500
+Yeah, I know.
+And so smelly.
+
+676
+00:50:16.601 --> 00:50:18.300
+And they're either too hot
+or too cold.
+
+677
+00:50:18.401 --> 00:50:19.900
+I know, the quality's
+really fallen off.
+
+678
+00:50:20.001 --> 00:50:23.100
+Oh, it's terrible! And there's always
+people talking. [...]
+
+679
+00:50:25.501 --> 00:50:27.700
+- [...] texting.
+- One second.
+
+680
+00:50:28.101 --> 00:50:29.100
+Hello?
+
+681
+00:50:29.201 --> 00:50:31.500
+Probably work.
+
+682
+00:50:37.401 --> 00:50:38.600
+So, yeah, we love it.
+
+683
+00:50:38.601 --> 00:50:41.000
+- It's so nice.
+- Well, you have to come.
+
+684
+00:50:41.001 --> 00:50:43.400
+You should. Come by.
+
+685
+00:51:00.701 --> 00:51:02.300
+I got one more
+for you, man:
+
+686
+00:51:02.401 --> 00:51:04.100
+- Mm-hmm.
+- Indonesia.
+
+687
+00:51:04.201 --> 00:51:05.800
+- I never heard of.
+- Anyone say that.
+
+688
+00:51:05.901 --> 00:51:07.300
+I don't remember
+all the track of it,
+
+689
+00:51:07.401 --> 00:51:09.000
+but honestly,
+it was just life changing.
+
+690
+00:51:09.101 --> 00:51:10.400
+- Really?
+- Yeah.
+
+691
+00:51:10.401 --> 00:51:12.000
+It did-did affected me. [...]
+
+692
+00:51:12.501 --> 00:51:13.600
+Is it amazing?
+
+693
+00:51:13.701 --> 00:51:14.800
+Yes.
+
+694
+00:51:14.801 --> 00:51:16.100
+A five-star
+jungle-eco resort.
+
+695
+00:51:16.201 --> 00:51:17.600
+- Wow.
+- You would not believe.
+
+696
+00:51:17.601 --> 00:51:18.600
+Amazing.
+
+697
+00:51:18.601 --> 00:51:19.600
+We were thinking
+about Nicaragua.
+
+698
+00:51:19.701 --> 00:51:21.400
+The thing 'bout Nicaragua
+is it's less developed.
+
+699
+00:51:21.501 --> 00:51:22.600
+- It's a bit underdeveloped.
+- Right.
+
+700
+00:51:22.701 --> 00:51:24.500
+You know? I think
+there's a little more offert.
+
+701
+00:51:24.601 --> 00:51:27.200
+Yeah, I just... I don't know,
+I don't know if it's safe there.
+
+702
+00:51:27.201 --> 00:51:28.500
+Yeah, yeah. [...]
+
+703
+00:52:00.401 --> 00:52:02.300
+I'm sorry.
+
+704
+00:53:36.201 --> 00:53:38.600
+[...] An immensity of our universe.
+
+705
+00:53:38.601 --> 00:53:41.400
+For many days,
+before the end of our Earth,
+
+706
+00:53:41.501 --> 00:53:44.900
+people will look into the night sky
+and notice a star,
+
+707
+00:53:45.001 --> 00:53:48.100
+increasingly bright
+and increasingly near.
+
+708
+00:53:48.201 --> 00:53:50.800
+As this star
+approaches us...
+
+709
+00:53:51.801 --> 00:53:53.900
+Jim Stark.
+
+710
+00:53:54.501 --> 00:53:56.100
+I'll go find a place.
+I'm sorry.
+
+711
+00:53:56.201 --> 00:53:58.500
+As this star
+approaches us,
+
+712
+00:53:58.501 --> 00:53:59.700
+the weather will change.
+
+713
+00:53:59.701 --> 00:54:02.200
+The great polar fields
+of the north and south
+
+714
+00:54:02.301 --> 00:54:06.900
+will rot and divide.
+And the seas will turn warmer.
+
+715
+00:54:07.201 --> 00:54:10.300
+The last of us search the heavens
+and stand amazed.
+
+716
+00:54:10.401 --> 00:54:12.800
+For the stars
+will still be there...
+
+717
+00:54:12.801 --> 00:54:14.700
+moving through their [...]
+
+718
+00:54:30.801 --> 00:54:32.900
+I have an idea.
+
+719
+00:55:08.701 --> 00:55:10.700
+TESLA COIL
+
+720
+00:58:53.101 --> 00:58:56.100
+GENEVIEVE: Holy hell!
+
+721
+00:59:07.601 --> 00:59:09.500
+What is that?
+Is that a script?
+
+722
+00:59:09.601 --> 00:59:12.100
+- It's a play.
+- A play?!
+
+723
+00:59:12.101 --> 00:59:13.900
+You better give us all roles!
+
+724
+00:59:13.901 --> 00:59:16.400
+Actually,
+it's a one-woman show!
+
+725
+00:59:16.401 --> 00:59:18.300
+So I can't.
+
+726
+00:59:22.601 --> 00:59:25.700
+Wow!
+Is that gonna happen everytime?
+
+727
+00:59:25.701 --> 00:59:27.100
+I think so.
+
+728
+00:59:42.201 --> 00:59:44.400
+Wait! It's one way.
+
+729
+00:59:49.901 --> 00:59:51.500
+SUMMER
+
+730
+01:02:05.101 --> 01:02:07.400
+- I love you.
+- Love you too.
+
+731
+01:02:21.501 --> 01:02:23.300
+Sebastian?
+
+732
+01:02:26.601 --> 01:02:28.000
+Keith.
+
+733
+01:02:28.101 --> 01:02:29.900
+Come here, man!
+
+734
+01:02:31.001 --> 01:02:32.800
+- How are you?
+- Very good, man.
+
+735
+01:02:32.801 --> 01:02:35.000
+This is Mia. Mia, Keith.
+
+736
+01:02:35.001 --> 01:02:36.900
+- Hi, Mia, nice to meet you.
+- Nice to meet you.
+
+737
+01:02:36.901 --> 01:02:38.600
+I used to play with this guy.
+
+738
+01:02:38.701 --> 01:02:40.300
+We went to school together.
+
+739
+01:02:40.301 --> 01:02:42.100
+- So, how you been, brother?
+- Great.
+
+740
+01:02:42.201 --> 01:02:43.500
+Never been better.
+How 'bout you?
+
+741
+01:02:43.601 --> 01:02:45.400
+I've been really good,
+been very busy.
+
+742
+01:02:45.501 --> 01:02:47.500
+- I got a new combo.
+- Okay.
+
+743
+01:02:47.601 --> 01:02:50.300
+- Cool.
+- We're looking for keys.
+
+744
+01:02:50.901 --> 01:02:53.300
+- You kidding me?
+- No, I'm not kidding.
+
+745
+01:02:53.401 --> 01:02:56.400
+- No, I'm good.
+- You sure? It pays.
+
+746
+01:02:56.701 --> 01:02:58.200
+I'm good.
+
+747
+01:02:58.201 --> 01:03:00.500
+Let's just grab a drink then.
+It's been too long.
+
+748
+01:03:00.601 --> 01:03:03.800
+- Okay. Nice to meet you, Mia.
+- Nice to meet you.
+
+749
+01:03:13.001 --> 01:03:15.000
+The end.
+
+750
+01:03:16.501 --> 01:03:18.100
+It's...
+
+751
+01:03:19.501 --> 01:03:21.200
+Genius.
+
+752
+01:03:21.201 --> 01:03:22.200
+- Really?
+- Yes.
+
+753
+01:03:22.301 --> 01:03:23.300
+- Really?
+- Yes.
+
+754
+01:03:23.401 --> 01:03:24.800
+It feels really nostalgic
+to me.
+
+755
+01:03:24.901 --> 01:03:25.900
+- That's the point.
+- Is it too nostalgic?
+
+756
+01:03:26.001 --> 01:03:28.300
+- That's...
+- Are people gonna like it?
+
+757
+01:03:28.601 --> 01:03:30.100
+Fuck 'em.
+
+758
+01:03:30.401 --> 01:03:33.700
+- You always say that.
+- Well, I truly believe that.
+
+759
+01:03:33.801 --> 01:03:36.200
+- I made you something.
+- For what?
+
+760
+01:03:36.201 --> 01:03:38.400
+For your club.
+
+761
+01:03:40.101 --> 01:03:41.400
+Why does it say "Seb's"?
+
+762
+01:03:41.401 --> 01:03:42.700
+'Cause I think you should
+call it "Seb's".
+
+763
+01:03:42.701 --> 01:03:43.700
+What?
+
+764
+01:03:43.701 --> 01:03:45.300
+'Cause no one's gonna come
+to "Chicken on a Stick".
+
+765
+01:03:45.401 --> 01:03:47.100
+Is that a music note
+as an apostrophe?
+
+766
+01:03:47.201 --> 01:03:48.300
+- Yes.
+- That's pretty cool.
+
+767
+01:03:48.401 --> 01:03:49.800
+- Yeah.
+- It's gotta be "Chicken on a Stick".
+
+768
+01:03:49.801 --> 01:03:50.800
+Hmm...
+
+769
+01:03:50.801 --> 01:03:52.900
+Because... Charlie Parker
+got his nickname...
+
+770
+01:03:53.001 --> 01:03:55.400
+...nickname
+because he loved chicken.
+
+771
+01:03:56.201 --> 01:03:58.400
+That's why they called him "Bird".
+
+772
+01:03:58.401 --> 01:04:01.300
+So I'm gonna have chicken,
+beer, jazz... "Chicken on a Stick!"
+
+773
+01:04:01.401 --> 01:04:03.000
+I know. I think you should
+drop the chicken
+
+774
+01:04:03.101 --> 01:04:05.200
+and just have drinks and jazz,
+and also there could be...
+
+775
+01:04:05.201 --> 01:04:06.200
+I'm not dropping the chicken.
+
+776
+01:04:06.201 --> 01:04:07.700
+You could maybe do it
+somewhere else?
+
+777
+01:04:07.801 --> 01:04:09.400
+- What're you talkin'...?
+- Find a new spot?
+
+778
+01:04:09.501 --> 01:04:12.000
+- It's gotta be the Van Beek.
+- It doesn't have to be the Van Beek.
+
+779
+01:04:12.101 --> 01:04:14.400
+I can't let them samba
+all over its history.
+
+780
+01:04:14.501 --> 01:04:16.400
+- Oh...
+- I can't do it.
+
+781
+01:04:16.501 --> 01:04:19.200
+You can let them,
+but you refuse to.
+
+782
+01:04:19.201 --> 01:04:21.200
+Your play's incredible.
+
+783
+01:04:21.501 --> 01:04:25.500
+You know? The whole world
+from your bedroom.
+
+784
+01:04:25.801 --> 01:04:27.900
+What else do they want?
+
+785
+01:04:28.001 --> 01:04:29.800
+Who's doing that?
+
+786
+01:04:30.101 --> 01:04:32.300
+- I'm doing that.
+- You're doing that?
+
+787
+01:04:33.201 --> 01:04:35.600
+Who was that guy
+at The Lighthouse?
+
+788
+01:04:36.201 --> 01:04:38.000
+- The guy that offered you the gig?
+- Keith.
+
+789
+01:04:38.101 --> 01:04:40.100
+Yeah. Why was it so weird
+between you two?
+
+790
+01:04:40.201 --> 01:04:42.700
+It's-It's just always weird...
+with him.
+
+791
+01:04:42.801 --> 01:04:44.300
+- Really?
+- Yeah.
+
+792
+01:04:44.401 --> 01:04:48.200
+But he seemed kinda nice
+because he did offer you a job.
+
+793
+01:04:48.601 --> 01:04:49.700
+Are you gonna call him?
+
+794
+01:04:49.801 --> 01:04:51.600
+No.
+
+795
+01:04:52.101 --> 01:04:54.900
+- No.
+- All right.
+
+796
+01:04:54.901 --> 01:04:56.900
+So...
+
+797
+01:04:57.201 --> 01:04:59.900
+- Here's what we know.
+- Yeah?
+
+798
+01:05:00.001 --> 01:05:02.800
+It's definitely
+"Chicken on a Stick"...
+
+799
+01:05:03.301 --> 01:05:06.300
+and your play's gonna be
+a triumph.
+
+800
+01:05:08.301 --> 01:05:10.000
+It's a one-woman show.
+
+801
+01:05:10.001 --> 01:05:12.800
+So it's just me. No, I... I mean,
+I'm acting in it.
+
+802
+01:05:12.801 --> 01:05:14.500
+It's gonnna be cool.
+
+803
+01:05:15.001 --> 01:05:19.700
+No, Mom, I-I'm not getting paid.
+I'm... paying to do it.
+
+804
+01:05:21.001 --> 01:05:23.600
+He's great. He's gonna open
+his own jazz club.
+
+805
+01:05:23.601 --> 01:05:26.000
+Yeah, it's gonna be incredible.
+
+806
+01:05:27.701 --> 01:05:31.500
+Uh, no. He's... He hasn't opened it
+yet. He needs, uh...
+
+807
+01:05:35.101 --> 01:05:37.600
+He's saving up, I think.
+
+808
+01:05:43.001 --> 01:05:44.900
+No, but he doesn't have
+a steady gig.
+
+809
+01:05:44.901 --> 01:05:46.700
+But he's-he's figuring it out.
+
+810
+01:05:46.701 --> 01:05:49.200
+It's just been a little
+tricky lately.
+
+811
+01:05:51.801 --> 01:05:53.700
+Mom, he's gonna find a way
+to open it
+
+812
+01:05:53.801 --> 01:05:55.200
+and you're gonna love it,
+okay?
+
+813
+01:05:55.201 --> 01:05:57.100
+How's Dad?
+
+814
+01:06:04.201 --> 01:06:06.000
+Sebastian!
+
+815
+01:06:06.101 --> 01:06:08.400
+Come on in, man.
+
+816
+01:06:09.001 --> 01:06:10.900
+- Thanks for comin'.
+- Thanks for having me.
+
+817
+01:06:11.001 --> 01:06:13.100
+I wasn't sure
+I'd see you today.
+
+818
+01:06:13.401 --> 01:06:15.300
+- So, here's the deal.
+- Okay.
+
+819
+01:06:15.401 --> 01:06:17.700
+- We got distribution with Universal.
+- Wow.
+
+820
+01:06:17.801 --> 01:06:19.900
+We've got our own imprint.
+We're about to go on the road.
+
+821
+01:06:20.001 --> 01:06:22.000
+Uh, we can pay you
+a thousand bucks a week...
+
+822
+01:06:22.101 --> 01:06:27.000
+plus a cut of the ticket revenue
+and merchandising. Sound good?
+
+823
+01:06:29.301 --> 01:06:30.500
+- Sebastian?
+- Yup.
+
+824
+01:06:30.501 --> 01:06:31.900
+All right?
+
+825
+01:06:31.901 --> 01:06:33.800
+- Let's play.
+- Okay.
+
+826
+01:07:24.701 --> 01:07:28.600
+<i>But I know I'll fell... [so good]
+tonight</i>
+
+827
+01:07:30.101 --> 01:07:33.600
+I know. It's different.
+
+828
+01:07:35.101 --> 01:07:37.400
+But you say you want
+to save jazz.
+
+829
+01:07:37.501 --> 01:07:40.100
+How are you gonna save jazz
+if no one's listening?
+
+830
+01:07:40.201 --> 01:07:42.400
+Jazz is dying
+because of people like you.
+
+831
+01:07:42.501 --> 01:07:46.800
+You're... playin' into 90-year-olds
+at The Lighthouse.
+
+832
+01:07:46.901 --> 01:07:49.800
+Where are the kids?
+Where are the young people?
+
+833
+01:07:49.901 --> 01:07:53.800
+You're so obsessed
+with Kenny Clarke and Thelonious Monk.
+
+834
+01:07:53.801 --> 01:07:55.900
+These guys were revolutionaries.
+
+835
+01:07:55.901 --> 01:07:57.900
+How are you going to be
+a revolutionary,
+
+836
+01:07:57.901 --> 01:07:59.900
+if you're such a traditionalist?
+
+837
+01:07:59.901 --> 01:08:04.700
+You're holding onto the past...,
+but jazz is about the future.
+
+838
+01:08:08.701 --> 01:08:10.400
+I know.
+
+839
+01:08:10.401 --> 01:08:14.500
+The other guy,
+he wasn't as good as you.
+
+840
+01:08:14.801 --> 01:08:18.300
+But you're a pain in the ass,
+man.
+
+841
+01:08:57.401 --> 01:09:00.300
+<i>City of stars,</i>
+
+842
+01:09:00.301 --> 01:09:04.400
+<i>Are you shining
+just for me?</i>
+
+843
+01:09:06.901 --> 01:09:09.900
+<i>City of stars,</i>
+
+844
+01:09:09.901 --> 01:09:14.100
+<i>There's so much
+that I can't see</i>
+
+845
+01:09:16.001 --> 01:09:18.800
+<i>Who knows?</i>
+
+846
+01:09:19.401 --> 01:09:25.700
+<i>I felt it from the first embrace
+I shared with you</i>
+
+847
+01:09:25.801 --> 01:09:33.800
+<i>That now our dreams
+may fin'lly come true</i>
+
+848
+01:09:36.101 --> 01:09:38.900
+<i>City of stars,</i>
+
+849
+01:09:38.901 --> 01:09:42.900
+<i>Just one thing
+ev'rybody wants</i>
+
+850
+01:09:45.301 --> 01:09:47.800
+<i>There in the bars</i>
+
+851
+01:09:47.801 --> 01:09:53.700
+<i>And through the smokescreen
+of the crowded restaurants</i>
+
+852
+01:09:53.701 --> 01:09:56.900
+<i>It's love</i>
+
+853
+01:09:56.901 --> 01:10:03.000
+<i>Yes, all we're looking for
+is love from someone else</i>
+
+854
+01:10:03.101 --> 01:10:05.300
+<i>- A rush
+- A glance</i>
+
+855
+01:10:05.401 --> 01:10:07.600
+<i>- A touch
+- A dance</i>
+
+856
+01:10:07.601 --> 01:10:10.800
+<i>A look in somebody's eyes</i>
+
+857
+01:10:10.901 --> 01:10:13.100
+<i>To light up the skies,</i>
+
+858
+01:10:13.101 --> 01:10:16.200
+<i>To open the world
+and send it reeling,</i>
+
+859
+01:10:16.201 --> 01:10:18.200
+<i>A voice that says</i>
+
+860
+01:10:18.201 --> 01:10:23.000
+<i>"I'll be here
+and you'll be alright"</i>
+
+861
+01:10:25.101 --> 01:10:30.200
+<i>I don't care if I know
+just where I will go,</i>
+
+862
+01:10:30.301 --> 01:10:33.400
+<i>'Cause all that I need's
+this crazy feeling</i>
+
+863
+01:10:33.401 --> 01:10:37.700
+<i>A rat-tat-tat on my heart</i>
+
+864
+01:10:37.801 --> 01:10:41.600
+<i>Think I want it to stay</i>
+
+865
+01:11:29.901 --> 01:11:32.000
+CONSIGNMENT
+
+866
+01:11:34.201 --> 01:11:40.500
+The Messengers interview
+on WTJM Chicago 98.8 FM
+
+867
+01:11:46.701 --> 01:11:48.700
+CLOSED
+
+868
+01:12:31.401 --> 01:12:34.300
+<i>City of stars,</i>
+
+869
+01:12:34.301 --> 01:12:38.800
+<i>Are you shining
+just for me?</i>
+
+870
+01:12:41.201 --> 01:12:45.100
+<i>City of stars,</i>
+
+871
+01:12:45.701 --> 01:12:52.700
+<i>You never shined
+so brightly</i>
+
+872
+01:13:20.801 --> 01:13:25.500
+<i>I don't know
+why I keep movin' my body</i>
+
+873
+01:13:25.601 --> 01:13:30.100
+<i>I don't know
+if this is wrong or if it's right</i>
+
+874
+01:13:30.401 --> 01:13:35.400
+<i>I don't know if it's the beat, but
+something's taking over me</i>
+
+875
+01:13:35.501 --> 01:13:42.400
+<i>And i just know
+I feel so good tonight</i>
+
+876
+01:13:47.201 --> 01:13:51.700
+<i>I don't know
+what your name is, but I like it</i>
+
+877
+01:13:51.801 --> 01:13:56.400
+<i>I've been thinking
+'bout some things I wanna try</i>
+
+878
+01:13:56.501 --> 01:13:59.000
+<i>I don't know
+what you came to do,</i>
+
+879
+01:13:59.001 --> 01:14:01.800
+<i>but I wanna do it with you</i>
+
+880
+01:14:01.801 --> 01:14:06.000
+<i>And I just know
+I feel so good tonight</i>
+
+881
+01:14:06.001 --> 01:14:10.200
+<i>Oh, if we keep on dancin',</i>
+
+882
+01:14:10.201 --> 01:14:15.900
+<i>Take our rhythm
+to new heights</i>
+
+883
+01:14:16.001 --> 01:14:20.700
+<i>Feel the heat of passion,
+baby,</i>
+
+884
+01:14:20.701 --> 01:14:24.100
+<i>light up the night</i>
+
+885
+01:14:24.201 --> 01:14:26.500
+<i>(We can start a fire)</i>
+
+886
+01:14:26.601 --> 01:14:28.900
+<i>Come on, let it burn, baby</i>
+
+887
+01:14:29.001 --> 01:14:31.200
+<i>(We can start a fire)</i>
+
+888
+01:14:31.301 --> 01:14:33.600
+<i>Let the tables turn, baby</i>
+
+889
+01:14:33.701 --> 01:14:39.400
+<i>(We can start a fire)</i>
+
+890
+01:14:39.401 --> 01:14:41.800
+<i>I just know
+I feel so good</i>
+
+891
+01:14:41.901 --> 01:14:44.200
+<i>Don't you know
+I feel so good?</i>
+
+892
+01:14:44.301 --> 01:14:48.600
+<i>I just know
+I feel so good...</i>
+
+893
+01:14:48.601 --> 01:14:51.400
+<i>tonight</i>
+
+894
+01:14:53.001 --> 01:14:57.800
+<i>I don't care
+if this turns into a riot</i>
+
+895
+01:14:57.901 --> 01:15:02.500
+<i>Let's get reckless,
+tear this place down to the floor</i>
+
+896
+01:15:02.601 --> 01:15:07.700
+<i>Turn the music way up loud
+Can't nobody stop us now</i>
+
+897
+01:15:07.801 --> 01:15:12.500
+<i>I just know I feel so good
+tonight, oh</i>
+
+898
+01:15:12.601 --> 01:15:16.700
+<i>I just know I feel so good
+tonight</i>
+
+899
+01:15:34.801 --> 01:15:37.100
+<i>(We can start a fire)</i>
+
+900
+01:15:37.201 --> 01:15:39.600
+<i>Come on, let it burn, baby</i>
+
+901
+01:15:39.701 --> 01:15:41.800
+<i>(We can start a fire)</i>
+
+902
+01:15:41.901 --> 01:15:44.200
+<i>Let the tables turn, baby</i>
+
+903
+01:15:44.301 --> 01:15:49.300
+<i>(We can start a fire)</i>
+
+904
+01:15:49.401 --> 01:15:50.400
+<i>Oh</i>
+
+905
+01:15:50.401 --> 01:15:52.500
+<i>I just know
+I feel so good</i>
+
+906
+01:15:52.601 --> 01:15:54.900
+<i>Don't you know
+I feel so good?</i>
+
+907
+01:15:55.001 --> 01:15:59.300
+<i>Don't you know?
+Don't you know?</i>
+
+908
+01:15:59.301 --> 01:16:00.900
+<i>Tonight</i>
+
+909
+01:16:09.501 --> 01:16:11.500
+FALL
+
+910
+01:16:19.901 --> 01:16:22.900
+SO LONG, BOULDER CITY
+
+911
+01:16:38.001 --> 01:16:39.800
+Hey, it's me.
+
+912
+01:16:39.801 --> 01:16:41.700
+Uh, I'm not sure
+where you are right now.
+
+913
+01:16:41.701 --> 01:16:43.000
+I think Boston?
+
+914
+01:16:43.101 --> 01:16:45.500
+Maybe Dallas, I don't know.
+
+915
+01:16:45.601 --> 01:16:47.400
+Uh...
+
+916
+01:16:47.401 --> 01:16:50.700
+I haven't heard from you
+in a little while...
+
+917
+01:16:51.401 --> 01:16:53.600
+and I miss you.
+
+918
+01:16:55.101 --> 01:16:57.200
+All right, bye.
+
+919
+01:17:33.001 --> 01:17:34.700
+I thought...
+
+920
+01:17:35.501 --> 01:17:37.300
+Surprise.
+
+921
+01:17:39.301 --> 01:17:40.800
+I gotta leave
+first thing in the morning,
+
+922
+01:17:40.801 --> 01:17:43.200
+but I just... I had to see you.
+
+923
+01:17:47.901 --> 01:17:50.000
+It's so nice to be home.
+
+924
+01:17:52.501 --> 01:17:54.600
+I'm so glad you're home.
+
+925
+01:17:56.701 --> 01:17:58.200
+How's the play going?
+
+926
+01:17:58.301 --> 01:18:00.600
+Uh... I'm nervous.
+
+927
+01:18:00.601 --> 01:18:01.600
+- You are?
+- Mm-hmm.
+
+928
+01:18:01.601 --> 01:18:02.600
+Why?
+
+929
+01:18:02.601 --> 01:18:04.600
+Because...
+what if people show up?
+
+930
+01:18:04.601 --> 01:18:06.300
+Pishi kaka.
+
+931
+01:18:06.301 --> 01:18:08.800
+You're nervous
+about what they think?
+
+932
+01:18:09.101 --> 01:18:11.900
+I'm nervous to do it.
+I'm nervous to get up...
+
+933
+01:18:12.001 --> 01:18:13.400
+on a stage
+and perform for people.
+
+934
+01:18:13.501 --> 01:18:14.800
+I mean, I don't need
+to say that to you.
+
+935
+01:18:14.901 --> 01:18:16.600
+- It's gonna be incredible.
+- You don't get it,
+
+936
+01:18:16.601 --> 01:18:18.500
+but I'm terrified.
+
+937
+01:18:18.501 --> 01:18:22.500
+They should be so lucky to see it.
+I can't wait.
+
+938
+01:18:22.501 --> 01:18:24.400
+I can.
+
+939
+01:18:26.301 --> 01:18:28.200
+When do you leave?
+In the morning?
+
+940
+01:18:28.501 --> 01:18:33.000
+Yeah. 6:45. Boise.
+
+941
+01:18:33.001 --> 01:18:35.100
+- Boisi?
+- Boise.
+
+942
+01:18:35.401 --> 01:18:37.200
+To Boise!
+
+943
+01:18:39.601 --> 01:18:41.500
+You should come.
+
+944
+01:18:42.401 --> 01:18:43.600
+To Boise?
+
+945
+01:18:43.601 --> 01:18:46.400
+Yeah, you can knock that off
+your bucket list.
+
+946
+01:18:46.501 --> 01:18:49.300
+Oh, that would be...
+really exciting. I wish I could.
+
+947
+01:18:49.401 --> 01:18:51.700
+What are you doin'
+after the tour?
+
+948
+01:18:52.201 --> 01:18:53.700
+Why can't you?
+
+949
+01:18:53.701 --> 01:18:54.900
+- Come to Boise?
+- Yeah.
+
+950
+01:18:54.901 --> 01:18:56.500
+'Cause I have to rehearse.
+
+951
+01:18:56.501 --> 01:18:59.500
+Yeah, but can't you rehearse
+anywhere?
+
+952
+01:19:02.001 --> 01:19:04.200
+Anywhere you are?
+
+953
+01:19:04.301 --> 01:19:07.200
+I mean... I guess.
+
+954
+01:19:07.301 --> 01:19:08.600
+Uh...
+
+955
+01:19:08.601 --> 01:19:11.000
+Well, all my stuff is here
+and it's in two weeks.
+
+956
+01:19:11.101 --> 01:19:13.600
+So I don't really think
+that would be...
+
+957
+01:19:13.901 --> 01:19:14.900
+Okay.
+
+958
+01:19:14.901 --> 01:19:16.800
+- the best idea right now,
+- Well...
+
+959
+01:19:16.801 --> 01:19:20.200
+but... I wish I could.
+
+960
+01:19:20.501 --> 01:19:22.400
+We're just gonna have to try
+and see each other, you know,
+
+961
+01:19:22.501 --> 01:19:25.900
+- so that we see each other.
+- I know, but when are you done?
+
+962
+01:19:26.401 --> 01:19:28.300
+What do you mean?
+I mean...
+
+963
+01:19:29.101 --> 01:19:31.000
+When you're finished
+with the whole tour?
+
+964
+01:19:31.101 --> 01:19:33.300
+But after we finish,
+we're gonna go to record
+
+965
+01:19:33.401 --> 01:19:35.200
+and then we'll go back
+on tour.
+
+966
+01:19:35.301 --> 01:19:37.000
+You know, we tour
+so we can make the record
+
+967
+01:19:37.101 --> 01:19:39.800
+so we can go back and tour
+the record.
+
+968
+01:19:43.001 --> 01:19:45.500
+So it's like the long haul?
+
+969
+01:19:48.401 --> 01:19:50.100
+What do you mean
+"the long haul"?
+
+970
+01:19:50.201 --> 01:19:53.200
+I mean the long haul
+like you're gonna stay in this band...
+
+971
+01:19:53.201 --> 01:19:55.400
+for a long time.
+
+972
+01:19:55.901 --> 01:19:58.000
+On tour.
+
+973
+01:19:59.201 --> 01:20:01.100
+I mean, what did you think
+I was going to do?
+
+974
+01:20:01.101 --> 01:20:02.400
+I don't... I...
+
+975
+01:20:02.401 --> 01:20:06.000
+I hadn't really thought it through.
+I didn't know that the band...
+
+976
+01:20:07.001 --> 01:20:08.100
+was so important.
+
+977
+01:20:08.101 --> 01:20:10.000
+You didn't think
+it would be successful?
+
+978
+01:20:10.001 --> 01:20:12.200
+Uh...
+
+979
+01:20:12.901 --> 01:20:14.300
+No, that's not really
+what I mean.
+
+980
+01:20:14.301 --> 01:20:15.500
+I just mean that you-you...
+
+981
+01:20:15.501 --> 01:20:17.700
+I mean... you're gonna be
+on tour for what?
+
+982
+01:20:17.701 --> 01:20:19.300
+Months now? Years?
+
+983
+01:20:19.301 --> 01:20:20.900
+Yeah, I don't belie...
+This is it.
+
+984
+01:20:21.001 --> 01:20:23.200
+I mean, this is-it could easibly
+be, yeah, for...
+
+985
+01:20:23.301 --> 01:20:24.900
+I could be on tour
+with this...
+
+986
+01:20:25.001 --> 01:20:28.100
+for a couple of years,
+at least just this record.
+
+987
+01:20:28.601 --> 01:20:31.600
+Do you like the music
+you're playing?
+
+988
+01:20:33.101 --> 01:20:34.900
+I don't...
+
+989
+01:20:34.901 --> 01:20:38.700
+I don't know...
+what-what it matters.
+
+990
+01:20:38.701 --> 01:20:40.200
+Well, it matters
+
+991
+01:20:40.201 --> 01:20:42.000
+because if you're going
+to give up your dream,
+
+992
+01:20:42.001 --> 01:20:43.200
+I think it matters
+
+993
+01:20:43.201 --> 01:20:45.100
+that you like
+what you're playing
+
+994
+01:20:45.101 --> 01:20:47.800
+on the road for years.
+
+995
+01:20:49.401 --> 01:20:51.100
+Do you like the music
+I'm playing?
+
+996
+01:20:51.101 --> 01:20:52.800
+Yeah.
+
+997
+01:20:54.101 --> 01:20:55.200
+I do.
+
+998
+01:20:55.201 --> 01:20:57.100
+I just didn't think
+that you did.
+
+999
+01:20:57.101 --> 01:20:58.200
+Yeah, well...
+
+1000
+01:20:58.301 --> 01:21:00.000
+You always said Keith is the worst
+
+1001
+01:21:00.001 --> 01:21:02.100
+and now you're gonna be
+on tour with him for years,
+
+1002
+01:21:02.201 --> 01:21:03.300
+- so I just didn't...
+- I don't know what-
+
+1003
+01:21:03.401 --> 01:21:04.500
+- what are you doing right now?
+- know if you were happy.
+
+1004
+01:21:04.601 --> 01:21:06.300
+- Why are you doing this?
+- I don't...
+
+1005
+01:21:06.401 --> 01:21:07.500
+What do you mean
+why am I doing this...?
+
+1006
+01:21:07.601 --> 01:21:09.300
+I thought you wanted me to do this
+and it just sounds like
+
+1007
+01:21:09.401 --> 01:21:10.700
+- now you don't want me to do it.
+- What do you mean
+
+1008
+01:21:10.701 --> 01:21:12.300
+I wanted you to do this?
+
+1009
+01:21:12.401 --> 01:21:14.600
+This is what you wanted for me.
+
+1010
+01:21:14.701 --> 01:21:15.900
+To be in this band?
+
+1011
+01:21:15.901 --> 01:21:18.400
+To be in a band to have
+a steady job, you know?
+
+1012
+01:21:18.401 --> 01:21:21.800
+To-To-To be... You know.
+
+1013
+01:21:22.101 --> 01:21:24.100
+Of course I wanted you
+to have a steady job,
+
+1014
+01:21:24.201 --> 01:21:26.300
+so that you could take care of yourself
+and your life
+
+1015
+01:21:26.401 --> 01:21:28.000
+- and you could start your club.
+- Yes, so I'm doing that,
+
+1016
+01:21:28.101 --> 01:21:30.000
+so I don't understand,
+well, why aren't we celebrating?
+
+1017
+01:21:30.001 --> 01:21:31.900
+Why aren't you starting your club?
+
+1018
+01:21:31.901 --> 01:21:34.400
+You said yourself no one
+wants to go to that club.
+
+1019
+01:21:34.501 --> 01:21:36.600
+No one wants to go to a club
+called "Chicken on a Stick".
+
+1020
+01:21:36.601 --> 01:21:37.900
+So change the name!
+
+1021
+01:21:37.901 --> 01:21:40.100
+Well, no one likes jazz!
+Not even you!
+
+1022
+01:21:40.201 --> 01:21:41.600
+I do like jazz now
+because of you!
+
+1023
+01:21:41.701 --> 01:21:44.300
+And this is what I thought
+you wanted me to do!
+
+1024
+01:21:44.401 --> 01:21:47.600
+What am I supposed to do?
+Go back to... playing Jingle Bells?
+
+1025
+01:21:47.701 --> 01:21:49.100
+I'm not saying that.
+I'm saying, why don't you...
+
+1026
+01:21:49.201 --> 01:21:52.100
+Scraping pennies? So I can start
+a club that no one wants to go?
+
+1027
+01:21:52.201 --> 01:21:53.600
+...take what you've made
+and start the club?!
+
+1028
+01:21:53.701 --> 01:21:55.600
+Then people will wanna go to it
+because you're passionate about it,
+
+1029
+01:21:55.701 --> 01:21:58.000
+and people love what other people
+are passionate about.
+
+1030
+01:21:58.101 --> 01:21:59.500
+You remind people
+of what they forgot.
+
+1031
+01:21:59.501 --> 01:22:01.800
+Not in my experience.
+
+1032
+01:22:04.201 --> 01:22:05.400
+Well, whatever, alright?
+
+1033
+01:22:05.401 --> 01:22:07.700
+I mean, it is-it's just-
+it's time to grow up, you know?
+
+1034
+01:22:07.801 --> 01:22:10.000
+I have a steady job,
+this is what I'm doing...
+
+1035
+01:22:10.101 --> 01:22:11.800
+And now all of a sudden
+if you had these problems,
+
+1036
+01:22:11.901 --> 01:22:13.200
+I wish you would've said them
+earlier
+
+1037
+01:22:13.301 --> 01:22:15.200
+before I signed
+on the goddamn dotted line!
+
+1038
+01:22:15.301 --> 01:22:16.900
+I'm pointing out
+that you had a dream
+
+1039
+01:22:17.001 --> 01:22:18.500
+that you followed,
+that you were sticking to...
+
+1040
+01:22:18.601 --> 01:22:20.900
+This is the dream!
+This is the dream.
+
+1041
+01:22:21.001 --> 01:22:22.500
+- This is not your dream!
+- Guys like me
+
+1042
+01:22:22.601 --> 01:22:25.500
+work their whole lives to be
+in something that's successful,
+
+1043
+01:22:25.601 --> 01:22:28.700
+that people like, you know?
+I mean, I'm finally
+
+1044
+01:22:28.801 --> 01:22:31.500
+in something that-that-that-
+that-that-that people enjoy.
+
+1045
+01:22:31.601 --> 01:22:33.500
+Since when do you care
+about being liked?
+
+1046
+01:22:33.601 --> 01:22:35.300
+Just 'cause I don't enjoy it,
+it doesn't matter.
+
+1047
+01:22:35.401 --> 01:22:37.000
+Why do you care so much
+about being liked?
+
+1048
+01:22:37.101 --> 01:22:39.900
+You are an actress!
+What are you talking about?!
+
+1049
+01:22:56.901 --> 01:22:58.700
+Maybe you just liked me
+when I was on my ass
+
+1050
+01:22:58.801 --> 01:23:03.400
+'cause it made you feel better
+about yourself.
+
+1051
+01:23:05.501 --> 01:23:08.200
+- Are you kidding?
+- No.
+
+1052
+01:23:29.101 --> 01:23:30.900
+I don't know...
+
+1053
+01:24:23.901 --> 01:24:26.400
+SO LONG, BOULDER CITY / TONIGHT
+
+1054
+01:24:50.201 --> 01:24:52.600
+Okay, fellas. I'll...
+see ya tomorrow.
+
+1055
+01:24:52.701 --> 01:24:54.000
+- Sebastian?
+- Yeah?
+
+1056
+01:24:54.101 --> 01:24:56.000
+You're good for tonight,
+right?
+
+1057
+01:24:57.201 --> 01:25:00.400
+- What are you talking about?
+- At 7, the photo shoot.
+
+1058
+01:25:01.201 --> 01:25:03.800
+For Mojo. You good?
+
+1059
+01:25:06.001 --> 01:25:10.000
+- I thought that was next thursday.
+- No, it's tonight.
+
+1060
+01:25:12.101 --> 01:25:14.000
+Is that okay?
+
+1061
+01:26:09.601 --> 01:26:11.800
+- Tonya, gimme the other camera!
+- What's wrong with that one?
+
+1062
+01:26:11.901 --> 01:26:12.900
+"What's wrong with that one"?
+I don't know.
+
+1063
+01:26:13.001 --> 01:26:15.200
+It does not bloody work!
+That's what's wrong with it!
+
+1064
+01:26:15.301 --> 01:26:17.800
+Alright, trumpet,
+that's lovely!
+
+1065
+01:26:18.501 --> 01:26:21.500
+Lovely! Beautiful, beautiful!
+
+1066
+01:26:21.601 --> 01:26:24.000
+Okay, keyboard.
+Okay, look up.
+
+1067
+01:26:24.101 --> 01:26:26.500
+That's good!
+That's good, that's lovely!
+
+1068
+01:26:26.501 --> 01:26:28.600
+Lovely. Okay, cut the music!
+
+1069
+01:26:28.601 --> 01:26:31.000
+That is lovely.
+That's lovely.
+
+1070
+01:26:31.101 --> 01:26:34.700
+Okay, now look.
+Now... bite your lip like...
+
+1071
+01:26:35.001 --> 01:26:36.900
+like you're concentrating
+on... on something,
+
+1072
+01:26:37.001 --> 01:26:39.100
+I don't know, like a piece of-
+a piece of your music.
+
+1073
+01:26:39.201 --> 01:26:41.900
+- Bite my what?
+- Your lip. You know, bite your lip.
+
+1074
+01:26:43.101 --> 01:26:44.300
+Okay.
+
+1075
+01:26:44.301 --> 01:26:46.900
+Yeah, that's good.
+That's great. Beautiful!
+
+1076
+01:26:46.901 --> 01:26:47.900
+Beautiful. Okay.
+
+1077
+01:26:47.901 --> 01:26:51.100
+Now just-just move your-move
+your glasses down on... on the nose.
+
+1078
+01:26:51.201 --> 01:26:53.300
+A little bit-A little bit bit further.
+Just a little bit, a touch further.
+
+1079
+01:26:53.401 --> 01:26:55.600
+Keep your head down,
+but look up at me.
+
+1080
+01:26:55.601 --> 01:26:57.400
+Look sort of... moody.
+
+1081
+01:26:57.401 --> 01:27:00.100
+Yeah! That's beautiful.
+That is great.
+
+1082
+01:27:00.101 --> 01:27:02.600
+Okay, turn the keyboard on live!
+
+1083
+01:27:03.201 --> 01:27:04.300
+You wanna hear
+the keyboard playin'?
+
+1084
+01:27:04.401 --> 01:27:07.100
+Nah. You don't have
+to bite your lip now.
+
+1085
+01:27:07.401 --> 01:27:09.400
+Well, actually play something.
+
+1086
+01:27:10.001 --> 01:27:11.800
+Play something, you know.
+Anything.
+
+1087
+01:27:11.901 --> 01:27:14.900
+You're pianist, aren't you?
+Play something.
+
+1088
+01:27:27.101 --> 01:27:30.000
+That's great. That's beautiful.
+That's lovely.
+
+1089
+01:27:30.101 --> 01:27:32.900
+Oh, that's good.
+Now don't stop, keep playing.
+
+1090
+01:27:33.001 --> 01:27:36.400
+Go on, just keep playing.
+That was great!
+
+1091
+01:28:15.401 --> 01:28:17.500
+Shoot myself in the head.
+
+1092
+01:28:18.901 --> 01:28:22.100
+- She's not even good.
+- That whole window thing...
+
+1093
+01:28:22.201 --> 01:28:23.200
+- What was that?
+- Yeah.
+
+1094
+01:28:23.301 --> 01:28:24.700
+What did she do
+with the window?!
+
+1095
+01:28:24.801 --> 01:28:27.500
+Oh my God!
+Don't quit your day job.
+
+1096
+01:28:27.501 --> 01:28:29.600
+Oh well...
+
+1097
+01:28:55.601 --> 01:28:57.400
+Mia!
+
+1098
+01:28:58.801 --> 01:29:02.200
+Mia. I'm so sorry.
+
+1099
+01:29:03.901 --> 01:29:07.300
+Just tell me how it went?
+How was it?
+
+1100
+01:29:07.301 --> 01:29:08.900
+I'm sorry.
+
+1101
+01:29:08.901 --> 01:29:10.500
+- I'm sorry I've been such a prick.
+- You're sorry...
+
+1102
+01:29:10.601 --> 01:29:12.600
+- I'm sorry I didn't come.
+- You're sorry... You sor...
+
+1103
+01:29:13.501 --> 01:29:16.200
+- You're sorry...
+- I'm gonna make it up to you.
+
+1104
+01:29:16.601 --> 01:29:19.000
+Let me make it up to you,
+okay?
+
+1105
+01:29:24.601 --> 01:29:27.200
+- I don't blame you for not wanting...
+- It's over.
+
+1106
+01:29:27.901 --> 01:29:30.100
+- What is?
+- It's over.
+
+1107
+01:29:30.101 --> 01:29:31.800
+What?
+
+1108
+01:29:33.001 --> 01:29:34.700
+All of this.
+
+1109
+01:29:34.701 --> 01:29:38.900
+I'm done embarrassing myself.
+I'm done. I'm done.
+
+1110
+01:29:39.201 --> 01:29:40.700
+- Nobody showed up.
+- What're you talkin'? So what?
+
+1111
+01:29:40.801 --> 01:29:44.100
+I can't pay back the theater!
+This is so...
+
+1112
+01:29:45.001 --> 01:29:47.200
+- I'm gonna go home for a while.
+- "I'm gonna..."?
+
+1113
+01:29:47.301 --> 01:29:50.400
+- I'll come see you tomorrow.
+- No, I'm going "home" home.
+
+1114
+01:29:50.701 --> 01:29:53.700
+- This is home.
+- No, it's not anymore.
+
+1115
+01:30:51.901 --> 01:30:53.900
+Theatre Background
+
+1116
+01:30:56.201 --> 01:30:58.700
+THEATRE / THEATHER / COMEDY /
+DRAMA / PLAY / STAGE / MUSICAL
+
+1117
+01:32:08.901 --> 01:32:09.900
+Yep?
+
+1118
+01:32:09.901 --> 01:32:12.500
+Hi, I'm trying to reach
+Mia Dolan.
+
+1119
+01:32:13.001 --> 01:32:14.200
+Wrong number.
+
+1120
+01:32:14.201 --> 01:32:16.700
+Yeah, she said if she's not on her cell,
+I was told I might find her here.
+
+1121
+01:32:16.701 --> 01:32:18.200
+Not anymore.
+
+1122
+01:32:18.201 --> 01:32:20.800
+- Okay. Well, if you do talk to her...
+- I won't.
+
+1123
+01:32:20.901 --> 01:32:24.900
+could you tell her Jane from Amy Brandt
+casting is trying to reach her?
+
+1124
+01:32:29.601 --> 01:32:31.400
+Casting?
+
+1125
+01:32:39.301 --> 01:32:41.600
+What the hell is that?
+
+1126
+01:32:46.001 --> 01:32:47.900
+Shut that thing off!
+
+1127
+01:32:58.301 --> 01:32:59.500
+Why did you come here?
+
+1128
+01:32:59.601 --> 01:33:01.500
+Because I have good news.
+
+1129
+01:33:01.601 --> 01:33:02.900
+What?
+
+1130
+01:33:02.901 --> 01:33:05.500
+Amy Brandt,
+the casting director.
+
+1131
+01:33:05.601 --> 01:33:07.900
+- Yeah?
+- She was at your play.
+
+1132
+01:33:07.901 --> 01:33:09.500
+And she loved it.
+
+1133
+01:33:09.601 --> 01:33:12.000
+And she loved it so much...
+
+1134
+01:33:12.001 --> 01:33:14.600
+that she wants you to come in
+tomorrow and audition for this...
+
+1135
+01:33:14.601 --> 01:33:16.900
+huge movie that she's got.
+
+1136
+01:33:17.901 --> 01:33:19.900
+I'm not going to that.
+
+1137
+01:33:21.601 --> 01:33:22.800
+- I'm not going to that.
+- What?
+
+1138
+01:33:22.901 --> 01:33:25.600
+That one's gonna be...
+No. That one's gonna be...
+
+1139
+01:33:25.601 --> 01:33:27.000
+I'm sorry?
+
+1140
+01:33:27.101 --> 01:33:29.200
+That will kill me.
+
+1141
+01:33:30.301 --> 01:33:33.500
+- What?!
+- What? What? Shh. Stop!
+
+1142
+01:33:33.601 --> 01:33:35.900
+- No!
+- Shh! Shh. You have to be quiet.
+
+1143
+01:33:36.001 --> 01:33:37.800
+If you want me to be,
+then you have to make sense.
+
+1144
+01:33:37.901 --> 01:33:39.100
+- They're gonna call...
+- If you want me to be quiet,
+
+1145
+01:33:39.201 --> 01:33:40.300
+you're gonna have to make
+some goddamn sense.
+
+1146
+01:33:40.401 --> 01:33:41.500
+- They're gonna call the police.
+- Tell me why you're not goin'.
+
+1147
+01:33:41.601 --> 01:33:42.700
+- Because? Because...
+- Why?
+
+1148
+01:33:42.801 --> 01:33:44.900
+I've been to a million of auditions,
+and the same thing happens every time.
+
+1149
+01:33:45.001 --> 01:33:47.700
+Or I get interrupted because
+someone wants to get a sandwich,
+
+1150
+01:33:47.801 --> 01:33:50.400
+or I'm crying
+and they start laughing!
+
+1151
+01:33:50.501 --> 01:33:52.500
+Or there's people sitting
+in the waiting room
+
+1152
+01:33:52.601 --> 01:33:55.400
+and they're... and they're...
+like me, but prettier...
+
+1153
+01:33:55.501 --> 01:33:58.500
+and better at the... because maybe
+I'm not good enough!
+
+1154
+01:33:58.601 --> 01:34:00.900
+- Yes, you are.
+- No.
+
+1155
+01:34:01.201 --> 01:34:02.500
+- No, maybe I'm not.
+- Yes, you are.
+
+1156
+01:34:02.601 --> 01:34:03.800
+- Maybe I'm not.
+- You are.
+
+1157
+01:34:03.901 --> 01:34:06.300
+- Maybe I'm not.
+- You are.
+
+1158
+01:34:07.901 --> 01:34:09.500
+Maybe I'm one
+of those people that...
+
+1159
+01:34:09.501 --> 01:34:11.800
+has always wanted to do it...
+
+1160
+01:34:11.801 --> 01:34:14.600
+but it's like a pipe dream
+for me,
+
+1161
+01:34:14.601 --> 01:34:15.800
+you know? And then you...
+
+1162
+01:34:15.801 --> 01:34:19.200
+You said it; you-you... change
+your dreams and then you grow up.
+
+1163
+01:34:19.301 --> 01:34:21.800
+Maybe I'm one of those people
+and I'm not supposed to.
+
+1164
+01:34:21.801 --> 01:34:23.700
+And I can go back to school...
+
+1165
+01:34:23.701 --> 01:34:26.000
+and I can find something else
+that I'm supposed to do.
+
+1166
+01:34:26.101 --> 01:34:28.800
+'Cause I left...
+to do that
+
+1167
+01:34:28.901 --> 01:34:32.700
+and it's been six years.
+And I don't wanna do it anymore.
+
+1168
+01:34:35.301 --> 01:34:37.000
+Why?
+
+1169
+01:34:39.201 --> 01:34:42.500
+- Why what?
+- Why don't you wanna do it anymore?
+
+1170
+01:34:44.001 --> 01:34:47.200
+'Cause I think it hurts
+far a bit too much.
+
+1171
+01:34:48.801 --> 01:34:50.400
+You're a baby.
+
+1172
+01:34:51.301 --> 01:34:52.700
+- I'm not a baby,
+- You are.
+
+1173
+01:34:52.801 --> 01:34:54.100
+- I'm trying to grow up.
+- You're crying like a baby.
+
+1174
+01:34:54.101 --> 01:34:55.100
+Oh my God!
+
+1175
+01:34:55.101 --> 01:34:57.600
+And you have an audition
+tomorrow at 5:30.
+
+1176
+01:34:57.901 --> 01:35:00.200
+I'll be out front at 8:00 am.
+
+1177
+01:35:00.601 --> 01:35:03.300
+You'll be out front or not,
+I don't know.
+
+1178
+01:35:04.501 --> 01:35:06.600
+How did you find me here?
+
+1179
+01:35:07.401 --> 01:35:09.300
+The house in front of the library.
+
+1180
+01:35:09.901 --> 01:35:12.900
+Del Prado Library
+Boulder City, NV
+
+1181
+01:35:52.501 --> 01:35:54.900
+- I got coffee.
+- Okay, great.
+
+1182
+01:36:13.001 --> 01:36:14.600
+Mia?
+
+1183
+01:36:19.901 --> 01:36:22.300
+Hi, Mia. I'm Amy
+and this is Frank.
+
+1184
+01:36:22.401 --> 01:36:24.500
+- Hi, how are you?
+- Pleasure to meet you.
+
+1185
+01:36:24.601 --> 01:36:27.700
+- Glad we found you.
+- Me too.
+
+1186
+01:36:28.401 --> 01:36:33.200
+The film shoots in Paris
+and we don't have a script.
+
+1187
+01:36:33.901 --> 01:36:37.500
+It's gonna be a process. We're gonna
+build the character around the actress.
+
+1188
+01:36:37.601 --> 01:36:40.500
+It's a three-month rehearsal
+and a four-month shoot.
+
+1189
+01:36:42.201 --> 01:36:43.800
+Okay.
+
+1190
+01:36:44.101 --> 01:36:47.600
+And we thought that
+you could just tell us a story.
+
+1191
+01:36:47.701 --> 01:36:51.500
+- About?
+- Hmm. You can just tell us anything.
+
+1192
+01:36:51.501 --> 01:36:52.600
+Anything?
+
+1193
+01:36:52.601 --> 01:36:56.000
+Yes. Just tell us a story.
+You're a storyteller.
+
+1194
+01:36:56.901 --> 01:36:58.800
+Uh...
+
+1195
+01:37:00.701 --> 01:37:02.900
+Whenever you're ready.
+
+1196
+01:37:12.601 --> 01:37:15.400
+My aunt used to live in Paris.
+
+1197
+01:37:19.801 --> 01:37:22.800
+I remember she used to come home
+and she would tell us...
+
+1198
+01:37:23.101 --> 01:37:27.300
+these stories about...
+being abroad and...
+
+1199
+01:37:28.801 --> 01:37:30.700
+I remember...
+
+1200
+01:37:31.101 --> 01:37:35.200
+she told us that
+she jumped into the river once.
+
+1201
+01:37:36.501 --> 01:37:38.300
+Barefoot.
+
+1202
+01:37:39.601 --> 01:37:42.000
+She smiled...
+
+1203
+01:37:42.601 --> 01:37:44.400
+<i>Leapt,</i>
+
+1204
+01:37:44.701 --> 01:37:47.200
+<i>without looking</i>
+
+1205
+01:37:49.701 --> 01:37:57.500
+<i>And tumbled into... the Seine</i>
+
+1206
+01:37:59.701 --> 01:38:03.800
+<i>The water was freezing</i>
+
+1207
+01:38:03.901 --> 01:38:08.100
+<i>She spent a month sneezing,</i>
+
+1208
+01:38:08.201 --> 01:38:14.300
+<i>But said she would do it again</i>
+
+1209
+01:38:16.001 --> 01:38:22.700
+<i>Here's to the ones who dream,</i>
+
+1210
+01:38:23.701 --> 01:38:30.400
+<i>Foolish
+as they may seem</i>
+
+1211
+01:38:31.401 --> 01:38:38.100
+<i>Here's to the hearts
+that ache</i>
+
+1212
+01:38:38.901 --> 01:38:45.700
+<i>Here's to the mess
+we make</i>
+
+1213
+01:38:46.801 --> 01:38:49.200
+<i>She captured a feeling,</i>
+
+1214
+01:38:49.301 --> 01:38:52.400
+<i>Sky with no ceiling,</i>
+
+1215
+01:38:52.501 --> 01:38:57.900
+<i>The sunset inside a frame</i>
+
+1216
+01:38:59.001 --> 01:39:02.200
+<i>She lived in her liquor</i>
+
+1217
+01:39:02.301 --> 01:39:05.600
+<i>And died with a flicker</i>
+
+1218
+01:39:05.601 --> 01:39:11.600
+<i>I'll always remember
+the flame</i>
+
+1219
+01:39:12.101 --> 01:39:18.300
+<i>Here's to the ones who dream,</i>
+
+1220
+01:39:18.301 --> 01:39:24.200
+<i>Foolish
+as they may seem</i>
+
+1221
+01:39:24.301 --> 01:39:30.300
+<i>Here's to the hearts
+that ache</i>
+
+1222
+01:39:30.401 --> 01:39:34.700
+<i>Here's to the mess
+we make</i>
+
+1223
+01:39:34.701 --> 01:39:38.300
+<i>She told me:</i>
+
+1224
+01:39:38.401 --> 01:39:42.000
+<i>"A bit of madness is key</i>
+
+1225
+01:39:42.301 --> 01:39:46.500
+<i>to give us new colors to see</i>
+
+1226
+01:39:47.201 --> 01:39:51.700
+<i>Who knows
+where it will lead us?</i>
+
+1227
+01:39:51.801 --> 01:39:56.200
+<i>And that's why
+they need us"</i>
+
+1228
+01:39:56.201 --> 01:39:59.700
+<i>So bring on the rebels,</i>
+
+1229
+01:39:59.701 --> 01:40:02.000
+<i>The ripples
+from pebbles,</i>
+
+1230
+01:40:02.101 --> 01:40:06.600
+<i>The painters,
+and poets and plays</i>
+
+1231
+01:40:06.701 --> 01:40:13.200
+<i>And here's to the fools
+who dream</i>
+
+1232
+01:40:13.301 --> 01:40:18.400
+<i>Crazy
+as they may seem</i>
+
+1233
+01:40:18.501 --> 01:40:23.700
+<i>Here's to the hearts
+that break</i>
+
+1234
+01:40:23.801 --> 01:40:30.400
+<i>Here's to the mess...
+we make</i>
+
+1235
+01:40:33.201 --> 01:40:39.300
+<i>I trace it
+all back to then,</i>
+
+1236
+01:40:41.301 --> 01:40:47.000
+<i>Her, and the snow
+and the Seine</i>
+
+1237
+01:40:49.601 --> 01:40:54.300
+<i>Smiling through it</i>
+
+1238
+01:40:54.801 --> 01:41:00.200
+<i>She said she'd do it...</i>
+
+1239
+01:41:02.001 --> 01:41:04.000
+<i>again</i>
+
+1240
+01:41:17.801 --> 01:41:19.900
+When do you find out?
+
+1241
+01:41:20.401 --> 01:41:22.800
+Uh, they said
+the next couple of days.
+
+1242
+01:41:22.901 --> 01:41:25.500
+But I'm not expecting
+to find anything out.
+
+1243
+01:41:25.601 --> 01:41:27.700
+- You're gonna get it.
+- I really might not.
+
+1244
+01:41:27.801 --> 01:41:29.300
+- Yes, you are.
+- And I don't want to be disappointed.
+
+1245
+01:41:29.301 --> 01:41:30.800
+I know.
+
+1246
+01:41:30.801 --> 01:41:34.200
+I know.
+I know these things.
+
+1247
+01:41:36.101 --> 01:41:38.000
+Where we are?
+
+1248
+01:41:40.701 --> 01:41:43.600
+- Griffith Park.
+- Where are we?
+
+1249
+01:41:43.601 --> 01:41:45.200
+I know.
+
+1250
+01:41:46.701 --> 01:41:48.500
+I don't know.
+
+1251
+01:41:51.001 --> 01:41:52.900
+What do we do?
+
+1252
+01:41:53.301 --> 01:41:56.100
+I don't think we can
+do anything.
+
+1253
+01:41:56.101 --> 01:41:58.000
+'Cause when you get this...
+
+1254
+01:41:58.001 --> 01:42:00.900
+- If I get this.
+- When you get this...
+
+1255
+01:42:02.101 --> 01:42:05.000
+you gotta give it
+everything you got.
+
+1256
+01:42:06.001 --> 01:42:09.800
+Everything.
+It's your dream.
+
+1257
+01:42:09.801 --> 01:42:11.700
+What are you gonna do?
+
+1258
+01:42:11.701 --> 01:42:13.500
+I gotta follow
+my own plan, you know?
+
+1259
+01:42:13.601 --> 01:42:17.200
+Stay here...
+and get my own thing going.
+
+1260
+01:42:21.801 --> 01:42:23.800
+You're gonna be in Paris...
+
+1261
+01:42:23.901 --> 01:42:26.000
+Good jazz there.
+
+1262
+01:42:26.301 --> 01:42:28.800
+And you love jazz now.
+
+1263
+01:42:29.901 --> 01:42:31.800
+Right?
+
+1264
+01:42:32.801 --> 01:42:34.500
+Yes.
+
+1265
+01:42:43.501 --> 01:42:46.800
+And I guess we're just gonna have
+to wait and see.
+
+1266
+01:42:54.701 --> 01:42:57.600
+I'm always gonna love you.
+
+1267
+01:42:58.301 --> 01:43:01.100
+I'm always gonna love you too.
+
+1268
+01:43:08.101 --> 01:43:10.000
+Look at this view!
+
+1269
+01:43:11.801 --> 01:43:12.800
+I've seen better.
+
+1270
+01:43:12.801 --> 01:43:13.900
+- It's the worst.
+- Yeah.
+
+1271
+01:43:13.901 --> 01:43:15.600
+Yeah.
+
+1272
+01:43:18.501 --> 01:43:21.200
+I've never been here
+during the day.
+
+1273
+01:43:32.301 --> 01:43:37.400
+WINTER
+
+1274
+01:43:45.701 --> 01:43:51.400
+Five years later...
+
+1275
+01:44:13.101 --> 01:44:15.000
+Hi. Can I have
+two iced coffees, please?
+
+1276
+01:44:15.001 --> 01:44:16.000
+Right, of course.
+
+1277
+01:44:16.001 --> 01:44:19.900
+- On us.
+- Oh! No, thank you. I insist.
+
+1278
+01:44:49.101 --> 01:44:51.000
+Sounds good!
+
+1279
+01:44:51.101 --> 01:44:53.100
+Harris did a good job.
+
+1280
+01:44:53.201 --> 01:44:54.200
+It took him long enough.
+
+1281
+01:44:54.201 --> 01:44:57.900
+It always does.
+Signature time.
+
+1282
+01:44:59.601 --> 01:45:01.600
+Not doing too bad, Seb.
+
+1283
+01:45:01.701 --> 01:45:03.300
+"Not too bad" is great.
+
+1284
+01:45:03.401 --> 01:45:04.500
+See ya tonight.
+
+1285
+01:45:04.601 --> 01:45:06.600
+See you tonight.
+
+1286
+01:45:26.401 --> 01:45:28.000
+Hi.
+
+1287
+01:45:28.001 --> 01:45:30.700
+- How was your day?
+- Good.
+
+1288
+01:45:34.501 --> 01:45:35.900
+- How is she?
+- She's great.
+
+1289
+01:45:36.001 --> 01:45:37.700
+- Yeah?
+- Yeah, come on.
+
+1290
+01:45:38.001 --> 01:45:39.600
+Hi, buddy!
+
+1291
+01:45:40.501 --> 01:45:43.200
+I didn't think
+you were gonna be home yet.
+
+1292
+01:45:44.201 --> 01:45:45.700
+Are you drawing?
+
+1293
+01:45:45.801 --> 01:45:46.800
+Yeah.
+
+1294
+01:45:46.801 --> 01:45:50.300
+Can I help?
+You know I love to draw.
+
+1295
+01:46:05.201 --> 01:46:07.200
+Happy Holidays
+from Laura Harry & Jordan
+
+1296
+01:46:22.701 --> 01:46:24.700
+Eleanor
+Starring Mia Dolan
+
+1297
+01:46:29.101 --> 01:46:32.100
+Okay, Chelsea, we're gonna go.
+Are you good?
+
+1298
+01:46:32.201 --> 01:46:34.200
+- We're good.
+- You need anything?
+
+1299
+01:46:34.501 --> 01:46:36.300
+Bye, baby.
+
+1300
+01:46:36.601 --> 01:46:37.700
+- Say "bye, Mommy".
+- Sleep well.
+
+1301
+01:46:37.801 --> 01:46:40.300
+- Bye, Mommy.
+- Have fun with Chelsea.
+
+1302
+01:46:40.401 --> 01:46:42.900
+- Have fun. Bye, Mia.
+- Bye. Thank you so much.
+
+1303
+01:46:43.001 --> 01:46:45.500
+- Good night, guys. Bye, sweetie!
+- Good night.
+
+1304
+01:46:54.901 --> 01:46:56.600
+Oh boy.
+
+1305
+01:46:57.801 --> 01:47:00.700
+What if we miss this?
+What're you gonna tell Natalie?
+
+1306
+01:47:01.301 --> 01:47:03.200
+Maybe we'll just see her
+back in New York.
+
+1307
+01:47:03.201 --> 01:47:04.700
+Okay.
+
+1308
+01:47:06.501 --> 01:47:10.000
+- I do not miss this.
+- It's bad.
+
+1309
+01:47:15.801 --> 01:47:18.700
+Do you wanna just pull off here
+and get dinner?
+
+1310
+01:47:20.801 --> 01:47:22.000
+- Sure, yeah.
+- Yeah?
+
+1311
+01:47:22.101 --> 01:47:24.000
+- Mm-hmm, yeah.
+- Okay.
+
+1312
+01:47:52.301 --> 01:47:54.300
+Do you wanna check it out?
+
+1313
+01:47:54.501 --> 01:47:56.000
+Okay.
+
+1314
+01:48:12.901 --> 01:48:14.900
+Seb's
+
+1315
+01:48:16.301 --> 01:48:18.700
+This place is pretty cool.
+
+1316
+01:48:28.301 --> 01:48:30.500
+I love it!
+
+1317
+01:49:18.801 --> 01:49:20.600
+- Cal Bennett on sax!
+- Yeah!
+
+1318
+01:49:20.601 --> 01:49:22.600
+Javier Gonzalez on trumpet.
+
+1319
+01:49:22.601 --> 01:49:25.100
+The lovely Nedra Wheeler
+on bass.
+
+1320
+01:49:25.201 --> 01:49:30.100
+The one and only
+Clifton "Fou Fou" Eddie on drums!
+
+1321
+01:49:30.201 --> 01:49:31.800
+And a little too good
+on piano,
+
+1322
+01:49:31.901 --> 01:49:34.500
+so good he's gonna own
+this place if I'm not careful,
+
+1323
+01:49:34.501 --> 01:49:36.800
+Khirye Tyler, everybody.
+
+1324
+01:49:49.401 --> 01:49:51.700
+Welcome to Seb's.
+
+1325
+01:51:41.501 --> 01:51:42.900
+I just heard you play,
+and I wanted to...
+
+1326
+01:52:50.501 --> 01:52:52.000
+STAGE DOOR
+
+1327
+01:54:14.001 --> 01:54:15.500
+CAVEAU de la HUCHETTE
+
+1328
+01:58:30.901 --> 01:58:33.200
+You want to stay for another?
+
+1329
+01:58:38.501 --> 01:58:40.000
+No, we should go.
+
+1330
+01:58:40.101 --> 01:58:41.600
+(Okay.)
+
+1331
+01:59:42.901 --> 01:59:46.100
+One, two...
+One, two, three, four.
+
+1332
+01:59:50.701 --> 01:59:55.700
+The End
+
+1333
+01:59:55.801 --> 02:00:00.800
+Subtitles: @marlonrock1986 (^^V^^)

--- a/test/examples/Man.Of.Steel.2013.720p.BluRay.x264.YIFI.srt
+++ b/test/examples/Man.Of.Steel.2013.720p.BluRay.x264.YIFI.srt
@@ -5538,7 +5538,7 @@ by SNUIF
 02:12:57,000 --> 02:13:00,000
 Source: PublicHD
 
-1297
+1298
 02:13:01,305 --> 02:13:07,267
 Support us and become VIP member
 to remove all ads from OpenSubtitles.org

--- a/test/examples/Man.Of.Steel.2013.720p.BluRay.x264.YIFI.vtt
+++ b/test/examples/Man.Of.Steel.2013.720p.BluRay.x264.YIFI.vtt
@@ -1,0 +1,5546 @@
+WEBVTT
+
+1
+00:00:06.000 --> 00:00:12.074
+Advertise your product or brand here
+contact www.OpenSubtitles.org today
+
+2
+00:00:50.000 --> 00:00:53.000
+Man.Of.Steel.2013.720p.BluRay.x264.YIFI
+
+3
+00:00:58.525 --> 00:01:00.027
+Hurry!
+
+4
+00:02:11.031 --> 00:02:14.979
+Do you not understand?
+Krypton's core is collapsing.
+
+5
+00:02:15.202 --> 00:02:18.547
+We may only have a matter of weeks.
+I warned you.
+
+6
+00:02:18.805 --> 00:02:22.309
+Harvesting the core was suicide.
+It has accelerated...
+
+7
+00:02:22.542 --> 00:02:25.284
+...the process of implosion.
+- Our energy reserves...
+
+8
+00:02:25.512 --> 00:02:27.890
+...were exhausted.
+What would you have us do, El?
+
+9
+00:02:28.148 --> 00:02:31.561
+Look to the stars, like our ancestors did.
+
+10
+00:02:31.818 --> 00:02:35.698
+There are habitable worlds within reach.
+We can begin by using the old outposts.
+
+11
+00:02:35.956 --> 00:02:39.665
+Are you seriously suggesting
+that we evacuate the entire planet?
+
+12
+00:02:39.893 --> 00:02:43.340
+No. Everybody here is already dead.
+
+13
+00:02:44.164 --> 00:02:47.702
+Give me control of the Codex.
+I will ensure the survival of our race.
+
+14
+00:02:48.669 --> 00:02:49.739
+There is still hope.
+
+15
+00:02:50.003 --> 00:02:52.506
+I have held that hope in my hands.
+
+16
+00:03:07.421 --> 00:03:09.560
+This council has been disbanded.
+
+17
+00:03:10.057 --> 00:03:11.900
+On whose authority?
+
+18
+00:03:12.259 --> 00:03:13.397
+Mine.
+
+19
+00:03:18.165 --> 00:03:21.442
+The rest of you will be tried
+and punished accordingly.
+
+20
+00:03:23.437 --> 00:03:26.008
+- What are you doing, Zod? This is madness.
+- What I should have done...
+
+21
+00:03:26.239 --> 00:03:26.910
+...years ago.
+
+22
+00:03:27.174 --> 00:03:28.209
+These lawmakers...
+
+23
+00:03:28.442 --> 00:03:29.546
+...with their endless debates...
+
+24
+00:03:29.776 --> 00:03:30.914
+...have lead Krypton to ruin.
+
+25
+00:03:34.281 --> 00:03:35.954
+And if your forces prevail...
+
+26
+00:03:36.216 --> 00:03:38.856
+...you'll be the leader of nothing.
+- Then join me.
+
+27
+00:03:39.086 --> 00:03:42.192
+Help me save our race. We'll start anew.
+
+28
+00:03:42.422 --> 00:03:43.457
+We'll sever...
+
+29
+00:03:43.724 --> 00:03:46.466
+...the degenerative bloodlines
+that led us to this state.
+
+30
+00:03:46.727 --> 00:03:49.970
+And who will decide
+which bloodlines survive, Zod?
+
+31
+00:03:51.531 --> 00:03:52.373
+You?
+
+32
+00:03:54.901 --> 00:03:56.608
+Don't do this, El.
+
+33
+00:03:56.870 --> 00:03:59.316
+The last thing I want
+is for us to be enemies.
+
+34
+00:03:59.573 --> 00:04:02.213
+You have abandoned the principles
+that bound us together.
+
+35
+00:04:02.442 --> 00:04:03.443
+You've taken up the sword...
+
+36
+00:04:03.710 --> 00:04:05.917
+...against your own people.
+
+37
+00:04:06.480 --> 00:04:09.393
+I will honor the man you once were, Zod...
+
+38
+00:04:09.816 --> 00:04:11.796
+...not this monster you've become.
+
+39
+00:04:15.088 --> 00:04:16.431
+Take him away.
+
+40
+00:04:22.596 --> 00:04:23.939
+Sir? Is everything all right?
+
+41
+00:04:24.164 --> 00:04:25.472
+Out of the way.
+
+42
+00:04:26.333 --> 00:04:26.936
+I said--
+
+43
+00:04:43.817 --> 00:04:44.852
+Get me Lara.
+
+44
+00:04:46.186 --> 00:04:48.359
+Jor. Behind you.
+
+45
+00:04:52.259 --> 00:04:54.261
+Lara, you have to ready the launch.
+
+46
+00:04:54.494 --> 00:04:56.167
+I'll be with you as soon as I can.
+
+47
+00:05:10.977 --> 00:05:12.149
+H'Raka!
+
+48
+00:05:23.957 --> 00:05:24.992
+Hyah!
+
+49
+00:05:51.585 --> 00:05:54.327
+- Can you see the Codex?
+- It's just beneath the central hub.
+
+50
+00:05:54.554 --> 00:05:55.692
+But I'm compelled to warn you.
+
+51
+00:05:55.922 --> 00:05:58.232
+Breaching the genesis chamber
+is a Class-B crime--
+
+52
+00:05:58.491 --> 00:06:02.064
+Nobody cares anymore, Kelex.
+The world is about to come to an end.
+
+53
+00:07:07.227 --> 00:07:09.901
+Jar-El, by the authority of General Zed...
+
+54
+00:07:10.130 --> 00:07:12.007
+...surrender the Codex.
+
+55
+00:07:27.580 --> 00:07:28.615
+Unh!
+
+56
+00:07:50.270 --> 00:07:51.340
+Ahhh!
+
+57
+00:08:00.013 --> 00:08:01.549
+Easy, H'Raka.
+
+58
+00:08:22.502 --> 00:08:23.742
+Did you find a world?
+
+59
+00:08:24.337 --> 00:08:26.647
+- We have.
+- Orbiting a main sequence yellow star...
+
+60
+00:08:26.873 --> 00:08:28.181
+“just as you said it would.
+
+61
+00:08:29.876 --> 00:08:31.480
+A young star.
+
+62
+00:08:31.845 --> 00:08:33.518
+His cells will drink its radiation.
+
+63
+00:08:36.649 --> 00:08:38.890
+It's a seemingly intelligent population.
+
+64
+00:08:39.819 --> 00:08:40.889
+He'll be an outcast.
+
+65
+00:08:41.888 --> 00:08:43.333
+A freak.
+
+66
+00:08:44.557 --> 00:08:45.365
+They'll kill him.
+
+67
+00:08:45.592 --> 00:08:47.037
+How?
+
+68
+00:08:47.894 --> 00:08:49.100
+He'll be a god to them.
+
+69
+00:08:51.431 --> 00:08:53.570
+What if the ship doesn't make it?
+
+70
+00:08:54.534 --> 00:08:55.535
+He'll die out there...
+
+71
+00:08:56.936 --> 00:08:58.279
+...alone.
+
+72
+00:09:00.073 --> 00:09:01.848
+I can't do it.
+
+73
+00:09:02.075 --> 00:09:03.452
+I thought I could, but...
+
+74
+00:09:03.710 --> 00:09:05.451
+- Lara.
+- ...now that he's here...
+
+75
+00:09:05.912 --> 00:09:07.619
+Krypton is doomed.
+
+76
+00:09:08.848 --> 00:09:10.691
+It's his only chance now.
+
+77
+00:09:11.384 --> 00:09:12.954
+It's our people's only hope.
+
+78
+00:09:14.421 --> 00:09:15.627
+What is it, Kelex?
+
+79
+00:09:15.889 --> 00:09:17.869
+Five attack ships
+converging from the east.
+
+80
+00:09:18.091 --> 00:09:20.435
+Citadel's defenses
+are being scanned and evaluated.
+
+81
+00:09:20.693 --> 00:09:21.603
+I'll upload the Codex.
+
+82
+00:09:22.362 --> 00:09:23.773
+No, wait.
+
+83
+00:09:24.397 --> 00:09:25.239
+Lara.
+
+84
+00:09:25.465 --> 00:09:28.378
+Just let me look at him.
+
+85
+00:09:31.771 --> 00:09:34.274
+We'll never get to see him walk.
+
+86
+00:09:36.709 --> 00:09:38.620
+Never hear him say our names.
+
+87
+00:09:44.050 --> 00:09:45.461
+But out there...
+
+88
+00:09:45.718 --> 00:09:47.629
+...amongst the stars...
+
+89
+00:09:48.988 --> 00:09:50.490
+...he will live.
+
+90
+00:10:48.548 --> 00:10:49.856
+Goodbye, my son.
+
+91
+00:10:51.184 --> 00:10:53.721
+Our hopes and dreams travel with you.
+
+92
+00:11:32.425 --> 00:11:35.235
+Concentrate fire on the main doors.
+
+93
+00:11:50.577 --> 00:11:51.555
+Lady Lara.
+
+94
+00:11:51.778 --> 00:11:54.850
+- The phantom drives are coming online.
+- Proceed to ignition.
+
+95
+00:11:55.615 --> 00:11:56.616
+General.
+
+96
+00:11:56.883 --> 00:12:00.262
+We have identified an engine ignition
+within the citadel.
+
+97
+00:12:01.221 --> 00:12:02.632
+A launch.
+
+98
+00:12:03.790 --> 00:12:06.202
+Hold this platform, commander.
+
+99
+00:12:18.605 --> 00:12:20.551
+I know you stole the Codex, Jor-El.
+
+100
+00:12:21.708 --> 00:12:22.709
+Surrender it...
+
+101
+00:12:22.942 --> 00:12:24.944
+...and I'll let you live.
+
+102
+00:12:25.578 --> 00:12:28.115
+This is a second chance for all of Krypton...
+
+103
+00:12:28.381 --> 00:12:30.725
+...not just the bloodlines you deem worthy.
+
+104
+00:12:32.252 --> 00:12:33.424
+What have you done?
+
+105
+00:12:33.653 --> 00:12:35.963
+We've had a child, Zod.
+
+106
+00:12:36.956 --> 00:12:38.333
+A boy child.
+
+107
+00:12:38.591 --> 00:12:41.595
+Krypton's first natural birth in centuries.
+
+108
+00:12:42.562 --> 00:12:44.269
+And he will be free.
+
+109
+00:12:44.764 --> 00:12:47.244
+Free to forge his own destiny.
+
+110
+00:12:48.101 --> 00:12:49.580
+Heresy.
+
+111
+00:12:51.471 --> 00:12:52.142
+Destroy it.
+
+112
+00:13:01.147 --> 00:13:02.182
+Ah!
+
+113
+00:13:45.625 --> 00:13:46.626
+Lara...
+
+114
+00:13:46.793 --> 00:13:48.170
+...listen to me.
+
+115
+00:13:48.394 --> 00:13:52.035
+The Codex is Krypton's future.
+
+116
+00:13:52.298 --> 00:13:54.744
+Abort the launch.
+
+117
+00:14:13.920 --> 00:14:15.695
+No!
+
+118
+00:14:45.618 --> 00:14:46.892
+Your son, Lara...
+
+119
+00:14:48.187 --> 00:14:50.098
+...where have you sent him?
+
+120
+00:14:53.593 --> 00:14:55.368
+His name...
+
+121
+00:14:55.595 --> 00:14:56.699
+...is Kal...
+
+122
+00:14:57.363 --> 00:14:59.206
+...son of El.
+
+123
+00:15:02.301 --> 00:15:04.645
+And he's beyond your reach.
+
+124
+00:15:15.281 --> 00:15:16.783
+Bring that ship down.
+
+125
+00:15:25.124 --> 00:15:26.501
+Target locked.
+
+126
+00:15:38.237 --> 00:15:39.682
+Lay down your weapons.
+
+127
+00:15:39.939 --> 00:15:42.010
+Your forces are surrounded.
+
+128
+00:15:52.118 --> 00:15:53.597
+General Zod...
+
+129
+00:15:53.820 --> 00:15:56.596
+...for the crimes
+of murder and high treason...
+
+130
+00:15:56.823 --> 00:16:00.032
+...the Council has sentenced you
+and your fellow insurgents...
+
+131
+00:16:01.194 --> 00:16:04.664
+...to three hundred cycles
+of somatic reconditioning.
+
+132
+00:16:06.165 --> 00:16:07.974
+Do you have any last words?
+
+133
+00:16:11.270 --> 00:16:12.214
+You won't kill us yourself!
+
+134
+00:16:13.706 --> 00:16:15.845
+You wouldn'l sully your hands!
+But you'll damn us...
+
+135
+00:16:16.108 --> 00:16:18.281
+...to a black hole for eternity!
+
+136
+00:16:20.346 --> 00:16:21.381
+Jor-El was right.
+
+137
+00:16:21.647 --> 00:16:25.322
+You're a pack of fools,
+every last one of you.
+
+138
+00:16:26.219 --> 00:16:27.391
+And you.
+
+139
+00:16:29.121 --> 00:16:31.567
+You believe your son is safe?
+
+140
+00:16:32.291 --> 00:16:33.998
+I will find him.
+
+141
+00:16:34.227 --> 00:16:37.538
+I will reclaim
+what you have taken from us.
+
+142
+00:16:39.966 --> 00:16:41.536
+I will find him.
+
+143
+00:16:42.735 --> 00:16:44.840
+I will find him, Lara.
+
+144
+00:16:47.907 --> 00:16:50.478
+I will find him!
+
+145
+00:17:00.319 --> 00:17:02.060
+Argh!
+
+146
+00:18:31.677 --> 00:18:34.817
+Lady Lara, shouldn't you find refuge?
+
+147
+00:18:35.615 --> 00:18:38.596
+There is no refuge, Kelor.
+
+148
+00:18:39.518 --> 00:18:41.498
+Jor-El was right.
+
+149
+00:18:43.923 --> 00:18:45.334
+This is the end.
+
+150
+00:18:57.370 --> 00:19:00.283
+Make a better world than ours, Kal.
+
+151
+00:20:32.431 --> 00:20:33.933
+Watch it, dumb-ass!
+
+152
+00:20:34.200 --> 00:20:36.703
+Keep your eyes open
+or you're gonna get squashed.
+
+153
+00:20:38.704 --> 00:20:41.150
+Where the hell did they find you,
+greenhorn?
+
+154
+00:20:41.407 --> 00:20:42.886
+Let's get this trap in the air.
+
+155
+00:20:43.109 --> 00:20:44.645
+Gentlemen, secure the deck.
+
+156
+00:20:44.910 --> 00:20:47.914
+We just got a distress call
+from a rig due west of us.
+
+157
+00:20:48.147 --> 00:20:49.455
+Secure the deck.
+
+158
+00:20:54.153 --> 00:20:55.723
+All civilian boats, stand clear.
+
+159
+00:20:55.955 --> 00:20:58.629
+The sub-sea valves failed
+and the rig is about to explode.
+
+160
+00:20:58.891 --> 00:21:01.235
+Roger, Coast Guard.
+What about the men left inside?
+
+161
+00:21:01.460 --> 00:21:03.804
+- Forget them. They're dead.
+- Greenhorn...
+
+162
+00:21:04.063 --> 00:21:06.100
+...fetch me my binoculars.
+
+163
+00:21:07.633 --> 00:21:08.976
+Greenhorn.
+
+164
+00:21:17.309 --> 00:21:20.847
+This is the last of the oxygen. I don't know
+how much longer we can hold out.
+
+165
+00:21:31.190 --> 00:21:33.932
+This is Coast Guard 6510.
+We'll make one more pass then get out.
+
+166
+00:21:36.762 --> 00:21:38.867
+Wait, wait.
+I got some guys on the helipad.
+
+167
+00:21:39.131 --> 00:21:39.700
+Right here!
+
+168
+00:21:45.271 --> 00:21:47.148
+Come on, come on! Let's go! Let's go!
+
+169
+00:21:47.339 --> 00:21:49.148
+- Let's go!
+- Let's go!
+
+170
+00:21:59.685 --> 00:22:00.857
+Get that last guy loaded.
+
+171
+00:22:01.120 --> 00:22:02.497
+We have got to go.
+
+172
+00:22:02.721 --> 00:22:04.394
+Hey, let's go. What are you doing?
+
+173
+00:22:10.529 --> 00:22:11.633
+Go! Go!
+
+174
+00:22:13.799 --> 00:22:14.834
+Argh!
+
+175
+00:22:22.508 --> 00:22:24.010
+Argh!
+
+176
+00:22:49.535 --> 00:22:51.572
+"when Kansas became a territory?
+
+177
+00:22:53.772 --> 00:22:54.750
+Clark.
+
+178
+00:22:56.742 --> 00:22:57.720
+Are you listening, Clark?
+
+179
+00:23:02.915 --> 00:23:04.861
+I asked if you could tell me who first...
+
+180
+00:23:05.084 --> 00:23:06.119
+...settled Kansas.
+
+181
+00:23:19.365 --> 00:23:20.537
+Are you all right, Clark?
+
+182
+00:23:28.974 --> 00:23:30.385
+Clark.
+
+183
+00:23:31.610 --> 00:23:32.918
+Clark.
+
+184
+00:23:36.482 --> 00:23:37.085
+Clark!
+
+185
+00:23:41.086 --> 00:23:42.622
+Clark, come out of there.
+
+186
+00:23:42.888 --> 00:23:44.231
+Leave me alone.
+
+187
+00:23:45.257 --> 00:23:46.827
+Clark, I have called your mother.
+
+188
+00:23:48.160 --> 00:23:49.230
+Clark?
+
+189
+00:23:51.063 --> 00:23:52.167
+Ah!
+
+190
+00:23:52.331 --> 00:23:53.332
+I'm here.
+
+191
+00:23:53.599 --> 00:23:55.579
+Clark, honey, it's Mom.
+
+192
+00:23:57.970 --> 00:23:59.005
+Will you open the door?
+
+193
+00:23:59.271 --> 00:24:01.251
+- What's wrong with him?
+- He's such a freak.
+
+194
+00:24:01.473 --> 00:24:02.315
+Crybaby.
+
+195
+00:24:02.574 --> 00:24:05.020
+His parents won't even let him play
+with other kids.
+
+196
+00:24:05.277 --> 00:24:06.278
+I know.
+
+197
+00:24:06.512 --> 00:24:07.354
+Sweetie.
+
+198
+00:24:08.514 --> 00:24:10.653
+How can I help you if you won't let me in?
+
+199
+00:24:10.916 --> 00:24:13.260
+The world's too big, Mom.
+
+200
+00:24:13.485 --> 00:24:15.123
+Then make it small.
+
+201
+00:24:17.489 --> 00:24:18.763
+Just, um...
+
+202
+00:24:21.593 --> 00:24:22.697
+...focus on my voice.
+
+203
+00:24:25.264 --> 00:24:27.210
+Pretend ifs an island...
+
+204
+00:24:27.366 --> 00:24:29.277
+...out in the ocean.
+
+205
+00:24:30.803 --> 00:24:32.111
+Can you see it?
+
+206
+00:24:35.808 --> 00:24:36.843
+I see it.
+
+207
+00:24:38.177 --> 00:24:40.179
+Then swim towards it, honey.
+
+208
+00:24:53.459 --> 00:24:55.302
+What's wrong with me, Mom?
+
+209
+00:24:57.896 --> 00:24:59.398
+Clark.
+
+210
+00:24:59.665 --> 00:25:01.167
+Clark.
+
+211
+00:25:29.828 --> 00:25:31.705
+- Did you get everything I need?
+- Yep.
+
+212
+00:25:31.930 --> 00:25:33.603
+Hold it, hold it.
+
+213
+00:26:23.449 --> 00:26:24.985
+Hey, ass-wipe.
+
+214
+00:26:25.551 --> 00:26:27.224
+What do you think? You see the game?
+
+215
+00:26:27.453 --> 00:26:29.956
+- Leave him alone, Pete.
+- What are you, his girlfriend?
+
+216
+00:26:30.222 --> 00:26:31.895
+I wanna hear what he has to say.
+
+217
+00:26:34.259 --> 00:26:34.930
+Come on...
+
+218
+00:26:35.160 --> 00:26:35.831
+...dick-splash.
+
+219
+00:26:55.614 --> 00:26:58.458
+Mos SCREAMING]
+
+220
+00:28:16.828 --> 00:28:17.829
+My son was there.
+
+221
+00:28:18.063 --> 00:28:20.270
+He was in the bus.
+
+222
+00:28:20.532 --> 00:28:23.342
+- He saw what Clark did.
+- I know he did.
+
+223
+00:28:24.269 --> 00:28:28.274
+- I'm sure what he thought he saw was--
+- Was an act of God, Jonathan.
+
+224
+00:28:29.341 --> 00:28:31.719
+This was providence.
+
+225
+00:28:35.447 --> 00:28:37.518
+I think you're blowing it out of proportion.
+
+226
+00:28:37.749 --> 00:28:41.026
+No, I'm not. Lana saw it too.
+
+227
+00:28:41.253 --> 00:28:42.254
+And the Fordham boy.
+
+228
+00:28:42.521 --> 00:28:43.727
+This isn't the first time...
+
+229
+00:28:43.956 --> 00:28:45.902
+...Clark's done something like this.
+
+230
+00:29:01.240 --> 00:29:03.083
+I just wanted to help.
+
+231
+00:29:03.542 --> 00:29:06.284
+I know you did, but we talked about this.
+
+232
+00:29:06.545 --> 00:29:07.819
+Right?
+
+233
+00:29:08.280 --> 00:29:10.988
+Right? We talked about this. You have...
+
+234
+00:29:11.483 --> 00:29:14.930
+Clark, you have to keep this side
+of yourself a secret.
+
+235
+00:29:15.387 --> 00:29:19.267
+What was I supposed to do?
+Just let them die?
+
+236
+00:29:24.062 --> 00:29:25.473
+Maybe.
+
+237
+00:29:27.399 --> 00:29:31.404
+There's more at stake here than just our lives,
+Clark, or the lives of those around us.
+
+238
+00:29:34.339 --> 00:29:35.750
+When the world...
+
+239
+00:29:36.675 --> 00:29:40.680
+When the world finds out what you can do
+it's gonna change everything. Our...
+
+240
+00:29:40.946 --> 00:29:43.517
+Our beliefs, our notions of...
+
+241
+00:29:43.782 --> 00:29:46.490
+...what it means to be human.
+Everything.
+
+242
+00:29:46.752 --> 00:29:49.528
+You saw how Pete's mom reacted, right?
+
+243
+00:29:49.788 --> 00:29:51.995
+She was scared, Clark.
+
+244
+00:29:53.125 --> 00:29:53.967
+Why?
+
+245
+00:29:55.827 --> 00:29:58.671
+People are afraid
+of what they don't understand.
+
+246
+00:29:58.930 --> 00:29:59.840
+Is she right?
+
+247
+00:30:01.967 --> 00:30:03.810
+Did God do this to me?
+
+248
+00:30:05.370 --> 00:30:06.872
+Tell me.
+
+249
+00:30:21.653 --> 00:30:23.326
+We found you in this.
+
+250
+00:30:25.290 --> 00:30:28.237
+We were sure the government
+was gonna show up on our doorstep...
+
+251
+00:30:28.493 --> 00:30:30.473
+...but no one ever came.
+
+252
+00:30:44.976 --> 00:30:46.649
+This was in that chamber with you.
+
+253
+00:30:49.181 --> 00:30:50.558
+I took it to a metallurgist...
+
+254
+00:30:50.816 --> 00:30:52.159
+...at Kansas State.
+
+255
+00:30:52.384 --> 00:30:54.990
+He said whatever it was made from
+didn't even...
+
+256
+00:30:55.921 --> 00:30:58.697
+Didn't even exist on the periodic table.
+
+257
+00:31:00.659 --> 00:31:01.831
+That's another way of saying...
+
+258
+00:31:02.060 --> 00:31:04.336
+...that it's not from this world, Clark.
+
+259
+00:31:06.431 --> 00:31:07.705
+And neither are you.
+
+260
+00:31:10.402 --> 00:31:11.938
+You're the answer, son.
+
+261
+00:31:12.204 --> 00:31:14.582
+You're the answer to
+"Are we alone in the universe?"
+
+262
+00:31:16.742 --> 00:31:18.187
+I don't wanna be.
+
+263
+00:31:18.410 --> 00:31:20.287
+And I don't blame you, son.
+
+264
+00:31:20.879 --> 00:31:23.587
+It'd be a huge burden for anyone to bear.
+
+265
+00:31:23.849 --> 00:31:27.262
+But you're not just anyone, Clark,
+and I have to believe that you were...
+
+266
+00:31:28.420 --> 00:31:30.263
+That you were sent here for a reason.
+
+267
+00:31:31.523 --> 00:31:34.094
+All these changes that you're
+going through, one day...
+
+268
+00:31:34.359 --> 00:31:37.704
+One day you're gonna think of them
+as a blessing. When that day comes...
+
+269
+00:31:37.929 --> 00:31:39.374
+...you have to make a choice.
+
+270
+00:31:39.598 --> 00:31:43.603
+A choice of whether to stand proud
+in front of the human race or not.
+
+271
+00:31:45.370 --> 00:31:48.044
+Can't I just keep pretending I'm your son?
+
+272
+00:31:48.740 --> 00:31:50.651
+You are my son.
+
+273
+00:31:55.113 --> 00:31:57.115
+But somewhere out there you've...
+
+274
+00:31:57.816 --> 00:32:01.059
+You have another father too,
+who gave you another name.
+
+275
+00:32:04.122 --> 00:32:04.964
+And he sent you here...
+
+276
+00:32:05.223 --> 00:32:06.998
+...for a reason, Clark.
+
+277
+00:32:08.760 --> 00:32:12.435
+And even if it takes you the rest of your life,
+you owe it to yourself...
+
+278
+00:32:12.664 --> 00:32:14.803
+...to find out what that reason is.
+
+279
+00:32:23.008 --> 00:32:26.854
+Bound by wild desire
+
+280
+00:32:27.078 --> 00:32:30.116
+I fell into a ring of fire
+
+281
+00:32:30.282 --> 00:32:32.455
+Wait a second.
+Aren't you here fer the exercise?
+
+282
+00:32:32.684 --> 00:32:34.357
+No, there was a change in the plans.
+
+283
+00:32:34.619 --> 00:32:36.690
+Somebody found something
+strange on Ellesmere.
+
+284
+00:32:37.255 --> 00:32:39.929
+- Aircom's making runs out there all week.
+- That rat hole?
+
+285
+00:32:40.158 --> 00:32:42.263
+- You gotta be kidding me.
+- I know. It's crazy.
+
+286
+00:32:42.494 --> 00:32:44.201
+The Americans are there too,
+lots of them.
+
+287
+00:32:44.463 --> 00:32:47.034
+- Anything else?
+- They're calling it an anomalous object.
+
+288
+00:32:47.299 --> 00:32:49.540
+- Whatever that means.
+- Back off, Ludlow. I'm serious.
+
+289
+00:32:49.801 --> 00:32:51.610
+- Oh, come on, Chrissy.
+- Knock it off.
+
+290
+00:32:51.837 --> 00:32:53.282
+- Sit down.
+- Let me go.
+
+291
+00:32:53.505 --> 00:32:55.178
+Hey. Leave her alone, man.
+
+292
+00:32:59.511 --> 00:33:01.218
+Or what, tough guy?
+
+293
+00:33:01.780 --> 00:33:05.193
+Or I'm gonna have to ask you to leave.
+
+294
+00:33:06.384 --> 00:33:09.456
+I think I'll probably just leave
+when I'm good and ready.
+
+295
+00:33:11.957 --> 00:33:12.731
+Ooh.
+
+296
+00:33:19.397 --> 00:33:21.070
+Oh, there he is.
+
+297
+00:33:28.373 --> 00:33:30.375
+It's not worth it, sweetie.
+
+298
+00:33:38.517 --> 00:33:40.895
+Hey, asshole, don't forget your tip.
+
+299
+00:33:43.054 --> 00:33:44.863
+Strike.
+
+300
+00:34:35.407 --> 00:34:36.818
+Thanks.
+
+301
+00:34:37.642 --> 00:34:38.882
+Hi.
+
+302
+00:34:39.110 --> 00:34:40.817
+Miss Lane. How you doing?
+
+303
+00:34:41.079 --> 00:34:43.286
+- Good.
+- Jed Eubanks, Arctic Cargo.
+
+304
+00:34:43.548 --> 00:34:45.789
+How far to the station?
+
+305
+00:34:46.251 --> 00:34:49.323
+- Camp's just over the rise. I'll walk you over.
+- Great.
+
+306
+00:34:49.588 --> 00:34:51.795
+Joe can take your bags. Joe.
+
+307
+00:34:52.057 --> 00:34:53.297
+Help her out.
+
+308
+00:34:53.558 --> 00:34:56.061
+Careful with those. They're heavy.
+
+309
+00:34:58.496 --> 00:35:00.134
+I gotta confess, Miss Lane...
+
+310
+00:35:00.398 --> 00:35:03.242
+...I'm not a fan of the Daily Planet.
+
+311
+00:35:03.635 --> 00:35:07.606
+But those pieces you wrote when you were
+embedded with the 1st Division were...
+
+312
+00:35:07.839 --> 00:35:09.682
+Well, they were pretty impressive.
+
+313
+00:35:09.941 --> 00:35:13.912
+Well, what can I say? I get writer's block
+if I'm not wearing a flak jacket.
+
+314
+00:35:19.618 --> 00:35:20.619
+Miss Lane.
+
+315
+00:35:20.852 --> 00:35:23.492
+I'm Colonel Hardy, U.S. Northcom.
+Dr. Emil Hamilton...
+
+316
+00:35:23.755 --> 00:35:24.859
+...from DARPA.
+
+317
+00:35:25.123 --> 00:35:26.295
+- You're early.
+- Hi.
+
+318
+00:35:26.524 --> 00:35:28.003
+We were expecting you tomorrow.
+
+319
+00:35:28.259 --> 00:35:30.705
+Which is why I showed up today.
+
+320
+00:35:31.363 --> 00:35:33.536
+Look, let's get one thing straight,
+guys, okay?
+
+321
+00:35:33.798 --> 00:35:36.642
+The only reason I'm here
+is because we're on Canadian soil...
+
+322
+00:35:36.868 --> 00:35:40.315
+...and the appellate court overruled
+your injunction to keep me away.
+
+323
+00:35:40.538 --> 00:35:42.677
+So if we're done measuring dicks...
+
+324
+00:35:42.941 --> 00:35:45.285
+...can you have your people
+show me what you found?
+
+325
+00:35:47.345 --> 00:35:48.483
+NA SA's EOS satellites...
+
+326
+00:35:48.713 --> 00:35:50.488
+...pinged the anomaly first.
+
+327
+00:35:50.715 --> 00:35:53.195
+The ice shelf plays hell
+on the echo soundings.
+
+328
+00:35:53.451 --> 00:35:55.795
+- But there's something there.
+- A submarine, maybe?
+
+329
+00:35:56.021 --> 00:35:56.829
+Soviet-era?
+
+330
+00:35:57.055 --> 00:35:58.659
+Doubtful. That's 300 meters.
+
+331
+00:35:58.890 --> 00:36:01.871
+Considerably larger than anything
+we know they built back then.
+
+332
+00:36:02.127 --> 00:36:03.367
+But herds the spooky pan.
+
+333
+00:36:04.562 --> 00:36:07.042
+The ice surrounding the object...
+
+334
+00:36:07.298 --> 00:36:10.370
+...it's nearly twenty thousand years old.
+
+335
+00:36:11.836 --> 00:36:12.678
+Miss Lane?
+
+336
+00:36:14.039 --> 00:36:15.313
+Try not to wander.
+
+337
+00:36:15.540 --> 00:36:18.646
+Temperatures drop to minus 40
+at night around here.
+
+338
+00:36:18.877 --> 00:36:21.153
+Wouldn't find your body till after spring.
+
+339
+00:36:24.149 --> 00:36:25.651
+And there you go.
+
+340
+00:36:29.220 --> 00:36:30.699
+What if I need to tinkle?
+
+341
+00:36:31.389 --> 00:36:33.027
+There's a bucket in the corner.
+
+342
+00:37:07.225 --> 00:37:09.398
+Where the hell are you going?
+
+343
+00:39:18.723 --> 00:39:20.100
+Hello'?
+
+344
+00:40:55.586 --> 00:40:58.692
+It's all right, it's all right,
+it's all right. It's all right.
+
+345
+00:41:13.004 --> 00:41:14.881
+You're hemorrhaging internally...
+
+346
+00:41:15.139 --> 00:41:17.517
+...and if I don't cauterize this bleed...
+
+347
+00:41:18.676 --> 00:41:19.347
+How can-l?
+
+348
+00:41:19.610 --> 00:41:22.147
+I can do things that other people can't.
+
+349
+00:41:23.147 --> 00:41:24.285
+Now hold my hand.
+
+350
+00:41:25.116 --> 00:41:26.686
+This is gonna hurt.
+
+351
+00:42:28.379 --> 00:42:30.518
+What Colonel Hardy
+and his team surmised...
+
+352
+00:42:30.748 --> 00:42:32.250
+...was a Soviet-era submarine...
+
+353
+00:42:32.517 --> 00:42:34.963
+...was actually something
+much more exotic.
+
+354
+00:42:35.219 --> 00:42:39.065
+An isotope analysis of the surrounding
+ice bores suggests that an object...
+
+355
+00:42:39.290 --> 00:42:43.136
+...had been trapped in the glacier
+for over 18, 000 years.
+
+356
+00:42:43.394 --> 00:42:44.930
+As for my rescuer?
+
+357
+00:42:45.196 --> 00:42:47.574
+He disappeared during
+the object's departure.
+
+358
+00:42:47.965 --> 00:42:50.377
+A background check revealed
+that his work history...
+
+359
+00:42:50.601 --> 00:42:52.706
+...and identity had been falsified.
+
+360
+00:42:52.937 --> 00:42:54.814
+The questions raised by my rescuer's...
+
+361
+00:42:55.073 --> 00:42:56.916
+"existence are frightening to contemplate...
+
+362
+00:42:57.141 --> 00:42:58.779
+...but I also know what I saw.
+
+363
+00:43:00.711 --> 00:43:03.282
+"And I have arrived
+at the inescapable conclusion...
+
+364
+00:43:03.548 --> 00:43:05.550
+...that the object and its occupant...
+
+365
+00:43:05.783 --> 00:43:07.729
+...did not originate on Earth."
+
+366
+00:43:09.454 --> 00:43:12.765
+I can't print this, Lois.
+You might have hallucinated half of it.
+
+367
+00:43:12.990 --> 00:43:15.095
+What about the contractors
+who corroborated...
+
+368
+00:43:15.326 --> 00:43:18.500
+...my story?
+- The Pentagon is denying that there was a ship.
+
+369
+00:43:18.763 --> 00:43:20.606
+Of course they are. They're supposed to.
+
+370
+00:43:20.832 --> 00:43:22.334
+It's the Pentagon.
+
+371
+00:43:22.600 --> 00:43:24.273
+Perry, it's me we're talking about.
+
+372
+00:43:24.502 --> 00:43:27.176
+- I'm a Pulitzer Prize-winning reporter.
+- Then act like it.
+
+373
+00:43:27.438 --> 00:43:29.577
+- Print it or I walk.
+- You can't.
+
+374
+00:43:29.807 --> 00:43:30.842
+You're under contract.
+
+375
+00:43:33.311 --> 00:43:37.316
+I'm not running a story
+about aliens walking among us.
+
+376
+00:43:43.621 --> 00:43:45.191
+Never gonna happen.
+
+377
+00:43:48.459 --> 00:43:50.837
+That's a Scotch, straight-up, for the lady.
+
+378
+00:43:51.095 --> 00:43:52.369
+I'm sending you the article.
+
+379
+00:43:52.630 --> 00:43:55.110
+My editor won't print it,
+but if it leaked online...
+
+380
+00:43:55.333 --> 00:43:56.641
+Got it.
+
+381
+00:43:56.868 --> 00:43:59.314
+But didn't you once describe my site...
+
+382
+00:43:59.537 --> 00:44:02.347
+...as a creeping cancer of falsehoods?
+
+383
+00:44:02.940 --> 00:44:05.511
+I stand by my words, Woodburn,
+but I want this story...
+
+384
+00:44:05.776 --> 00:44:06.948
+...out there.
+- Why?
+
+385
+00:44:07.979 --> 00:44:11.324
+Because I want my mystery man
+to know I know the truth.
+
+386
+00:44:25.663 --> 00:44:27.643
+Recursive diagnostics complete.
+
+387
+00:44:28.466 --> 00:44:30.673
+Guiding presence authenticated.
+
+388
+00:44:30.902 --> 00:44:33.473
+All systems operational.
+
+389
+00:44:45.550 --> 00:44:49.498
+To see you standing there
+having grown into an adult...
+
+390
+00:44:51.722 --> 00:44:53.565
+If only Lara could have witnessed this.
+
+391
+00:44:54.692 --> 00:44:55.898
+Who are you?
+
+392
+00:44:56.894 --> 00:44:58.874
+I am your father, Kal.
+
+393
+00:45:00.231 --> 00:45:02.108
+Or at least a shadow of him.
+
+394
+00:45:02.600 --> 00:45:04.341
+His consciousness.
+
+395
+00:45:06.103 --> 00:45:09.209
+My name was Jor-El.
+
+396
+00:45:11.876 --> 00:45:13.514
+And Kal?
+
+397
+00:45:16.747 --> 00:45:17.953
+That's my name.
+
+398
+00:45:18.849 --> 00:45:22.058
+It is.
+
+399
+00:45:22.753 --> 00:45:24.790
+I have so many questions.
+
+400
+00:45:27.525 --> 00:45:29.129
+Where do I come from?
+
+401
+00:45:30.861 --> 00:45:32.738
+Why did you send me here?
+
+402
+00:45:33.564 --> 00:45:35.441
+You came from Krypton.
+
+403
+00:45:38.135 --> 00:45:42.140
+A world with a much harsher environment
+than Earths.
+
+404
+00:45:45.943 --> 00:45:47.581
+Long ago...
+
+405
+00:45:47.812 --> 00:45:50.053
+...in an era of expansion...
+
+406
+00:45:50.281 --> 00:45:53.490
+...our race spread out through the stars...
+
+407
+00:45:53.751 --> 00:45:56.459
+...seeking new worlds to settle upon.
+
+408
+00:45:57.588 --> 00:46:01.092
+This scout ship was
+one of thousands launched into the void.
+
+409
+00:46:03.661 --> 00:46:06.267
+We built outposts on other planets...
+
+410
+00:46:06.497 --> 00:46:10.240
+musing great machines to reshape
+environments to our needs.
+
+411
+00:46:12.436 --> 00:46:16.441
+For 100,000 years,
+our civilization ﬂourished...
+
+412
+00:46:17.975 --> 00:46:19.977
+...accomplishing wonders.
+
+413
+00:46:21.145 --> 00:46:22.783
+What happened?
+
+414
+00:46:24.782 --> 00:46:27.854
+Artificial population control
+was established.
+
+415
+00:46:28.586 --> 00:46:32.193
+The outposts on space exploration
+were abandoned.
+
+416
+00:46:32.790 --> 00:46:35.361
+We exhausted our natural resources.
+
+417
+00:46:35.626 --> 00:46:39.631
+As a result,
+our planet's core became unstable.
+
+418
+00:46:42.099 --> 00:46:44.636
+Eventually, our military leader...
+
+419
+00:46:44.869 --> 00:46:48.783
+...General Zod, attempted a coup.
+
+420
+00:46:50.708 --> 00:46:52.881
+But by then it was too late.
+
+421
+00:46:54.145 --> 00:46:56.785
+Your mother and I foresaw
+the coming calamity...
+
+422
+00:46:57.014 --> 00:46:59.824
+...and we took certain steps
+to ensure your survival.
+
+423
+00:47:01.886 --> 00:47:03.524
+This is a genesis chamber.
+
+424
+00:47:04.388 --> 00:47:07.528
+All Kryptonians were conceived
+in chambers such as this.
+
+425
+00:47:07.792 --> 00:47:11.501
+Every child was designed to fulfill
+a pare-determined role in our society...
+
+426
+00:47:11.729 --> 00:47:12.571
+...as a worker...
+
+427
+00:47:12.830 --> 00:47:15.970
+...a warrior, a leader and so on.
+
+428
+00:47:16.200 --> 00:47:19.477
+Your mother and I believed Krypton
+lost something precious.
+
+429
+00:47:19.704 --> 00:47:21.911
+The element of choice, of chance.
+
+430
+00:47:22.406 --> 00:47:24.579
+What if a child dreamed
+of becoming something...
+
+431
+00:47:24.842 --> 00:47:27.345
+mother than what society
+had intended for him or her?
+
+432
+00:47:28.879 --> 00:47:31.485
+What if a child aspired
+to something greater?
+
+433
+00:47:32.249 --> 00:47:34.251
+You were the embodiment
+of that belief, Kal.
+
+434
+00:47:34.518 --> 00:47:36.998
+Krypton's first natural birth in centuries.
+
+435
+00:47:38.089 --> 00:47:40.763
+That's why we risked so much to save you.
+
+436
+00:47:41.892 --> 00:47:43.337
+Why didn't you come with me?
+
+437
+00:47:46.864 --> 00:47:48.605
+We couldn't, Kal.
+
+438
+00:47:49.667 --> 00:47:50.668
+No matter how much...
+
+439
+00:47:50.901 --> 00:47:52.107
+...we wanted to.
+
+440
+00:47:52.603 --> 00:47:54.605
+No matter how much we loved you.
+
+441
+00:47:55.373 --> 00:47:56.750
+Your mother, Lara, and I...
+
+442
+00:47:57.007 --> 00:48:00.113
+...were a product of the failures
+of our world as much as Zod was...
+
+443
+00:48:00.378 --> 00:48:02.051
+...tied to its fate.
+
+444
+00:48:02.279 --> 00:48:04.350
+- So I'm alone.
+- No.
+
+445
+00:48:06.083 --> 00:48:09.758
+You're as much a child of Earth now
+as you are of Krypton.
+
+446
+00:48:10.020 --> 00:48:13.194
+You can embody the best of both worlds.
+
+447
+00:48:13.424 --> 00:48:17.065
+A dream your mother and I
+dedicated our lives to preserve.
+
+448
+00:48:21.599 --> 00:48:24.580
+The people of Earth
+are different from us, it's true.
+
+449
+00:48:24.802 --> 00:48:27.749
+But, ultimately,
+I believe that's a good thing.
+
+450
+00:48:27.972 --> 00:48:30.418
+They won't necessarily
+make the same mistakes we did.
+
+451
+00:48:30.641 --> 00:48:32.621
+Not if you guide them, Kal.
+
+452
+00:48:34.211 --> 00:48:36.248
+Not if you give them hope.
+
+453
+00:48:39.650 --> 00:48:41.823
+That's what this symbol means.
+
+454
+00:48:42.553 --> 00:48:44.897
+The symbol of the house of El
+means hope.
+
+455
+00:48:45.122 --> 00:48:47.625
+Embodied within that hope
+is the fundamental belief...
+
+456
+00:48:47.892 --> 00:48:51.806
+...in the potential of every person
+to be a force for good.
+
+457
+00:48:52.930 --> 00:48:54.967
+That's what you can bring them.
+
+458
+00:49:15.152 --> 00:49:16.995
+Why am I so different from them?
+
+459
+00:49:18.255 --> 00:49:20.758
+Earth's sun is younger and brighter
+than Krypton's was.
+
+460
+00:49:22.660 --> 00:49:25.038
+Your cells have drunken its radiation...
+
+461
+00:49:25.296 --> 00:49:29.301
+“strengthening your muscles,
+your skin, your senses.
+
+462
+00:49:29.834 --> 00:49:33.839
+Earth's gravity is weaker,
+yet its atmosphere is more nourishing.
+
+463
+00:49:35.139 --> 00:49:38.143
+You've grown stronger here
+than I ever could have imagined.
+
+464
+00:49:38.375 --> 00:49:39.979
+The only way to know how strong...
+
+465
+00:49:41.045 --> 00:49:44.185
+...is to keep testing your limits.
+
+466
+00:50:02.967 --> 00:50:03.638
+Unh!
+
+467
+00:50:11.342 --> 00:50:13.185
+Uh-- Oh.
+
+468
+00:50:14.812 --> 00:50:16.086
+Whoa!
+
+469
+00:50:36.433 --> 00:50:40.438
+You will give the people ofEart/v
+an ideal to strive towards.
+
+470
+00:50:42.106 --> 00:50:43.915
+They'll race behind you.
+
+471
+00:50:44.174 --> 00:50:45.551
+They will stumble.
+
+472
+00:50:45.776 --> 00:50:46.914
+They will fall.
+
+473
+00:50:47.177 --> 00:50:48.884
+But in time...
+
+474
+00:50:50.414 --> 00:50:53.054
+...they will join you in the sun, Kal.
+
+475
+00:50:54.552 --> 00:50:56.259
+In time...
+
+476
+00:50:56.587 --> 00:50:59.193
+you will help them accomplish wonders.
+
+477
+00:52:21.605 --> 00:52:25.553
+How do you find someone who has
+spent a lifetime covering his tracks?
+
+478
+00:52:25.943 --> 00:52:27.547
+You start with the urban legends...
+
+479
+00:52:27.811 --> 00:52:30.155
+- ...that have sprung up in his wake.
+- That's Joe.
+
+480
+00:52:30.381 --> 00:52:31.792
+The friends of a friend...
+
+481
+00:52:32.016 --> 00:52:34.018
+- ...who have seen him.
+- He worked here.
+
+482
+00:52:34.284 --> 00:52:37.128
+For some he was a guardian angel.
+For others, a cipher...
+
+483
+00:52:37.354 --> 00:52:39.129
+...a ghost who never quite fit in.
+
+484
+00:52:40.024 --> 00:52:41.503
+Well, I was saying we were...
+
+485
+00:52:41.725 --> 00:52:42.965
+...coming towards the oil rig.
+
+486
+00:52:43.193 --> 00:52:46.333
+As you work your way back in time,
+the stories form a pattern.
+
+487
+00:52:47.064 --> 00:52:49.135
+I'm looking for a Pete Ross.
+Do you know him?
+
+488
+00:52:49.366 --> 00:52:52.210
+Yeah, he works at the IHOP.
+If you go down the road...
+
+489
+00:52:54.138 --> 00:52:54.843
+Pete Ross?
+
+490
+00:52:57.174 --> 00:53:00.383
+I'd like to talk to you about an accident
+when you were younger.
+
+491
+00:53:00.644 --> 00:53:03.147
+A school bus that went into the river.
+
+492
+00:53:08.652 --> 00:53:10.757
+Dusty. Shh-shh-shh.
+
+493
+00:53:10.921 --> 00:53:11.991
+Mrs. Kent?
+
+494
+00:53:12.923 --> 00:53:14.869
+I'm Lois Lane. I'm from the Daily Planet.
+
+495
+00:53:15.926 --> 00:53:16.666
+Quiet.
+
+496
+00:53:18.262 --> 00:53:21.732
+I'm from the Daily Planet
+and I'd like to talk to you about your son.
+
+497
+00:53:39.850 --> 00:53:43.855
+I figured if I turned over enough stones
+you'd eventually find me.
+
+498
+00:53:49.426 --> 00:53:52.464
+Where are you from?
+What are you doing here?
+
+499
+00:53:52.730 --> 00:53:54.073
+Let me tell your story.
+
+500
+00:53:54.298 --> 00:53:57.438
+What if I don't want my story told?
+
+501
+00:53:57.701 --> 00:53:59.476
+It's going to come out eventually.
+
+502
+00:53:59.737 --> 00:54:02.775
+Somebody's going to get a photograph
+or figure out where you live.
+
+503
+00:54:03.040 --> 00:54:05.987
+- Then I'll disappear again.
+- The only way you could disappear...
+
+504
+00:54:06.243 --> 00:54:10.248
+...is to stop helping people altogether,
+and I sense that's not an option for you.
+
+505
+00:54:14.418 --> 00:54:18.423
+My father believed that if the world
+found out who I really was...
+
+506
+00:54:20.424 --> 00:54:21.425
+...they'd reject me...
+
+507
+00:54:22.159 --> 00:54:23.797
+...out of fear.
+
+508
+00:54:25.829 --> 00:54:27.900
+I'm tired of safe.
+
+509
+00:54:28.132 --> 00:54:30.237
+I just wanna do something useful
+with my life.
+
+510
+00:54:30.467 --> 00:54:33.073
+So farming, feeding people.
+That's not useful?
+
+511
+00:54:33.303 --> 00:54:34.145
+I didn't say that.
+
+512
+00:54:34.404 --> 00:54:36.509
+Our family's been farming
+for five generations.
+
+513
+00:54:36.774 --> 00:54:38.685
+Your family, not mine.
+
+514
+00:54:38.942 --> 00:54:41.923
+I don't even know why I'm listening to you.
+You're not my dad.
+
+515
+00:54:42.146 --> 00:54:43.523
+You're just some guy
+who found me in a field.
+
+516
+00:54:43.781 --> 00:54:44.953
+Clark.
+
+517
+00:54:47.317 --> 00:54:48.990
+It's all right, Martha.
+
+518
+00:54:50.821 --> 00:54:52.926
+He's right. Clark has a point.
+
+519
+00:54:53.490 --> 00:54:54.525
+We're not your parents.
+
+520
+00:54:56.627 --> 00:54:58.334
+But we've been doing the best we can.
+
+521
+00:54:58.595 --> 00:55:01.974
+And we've been making this up
+as we go along, so maybe...
+
+522
+00:55:02.199 --> 00:55:04.611
+Maybe our best
+isn't good enough anymore.
+
+523
+00:55:09.640 --> 00:55:11.677
+Look, Dad--
+
+524
+00:55:11.942 --> 00:55:13.387
+Hold on.
+
+525
+00:55:33.130 --> 00:55:34.837
+Go for the overpass.
+
+526
+00:55:36.633 --> 00:55:37.737
+Go for the overpass!
+
+527
+00:55:40.070 --> 00:55:41.708
+Take cover! Take cover!
+
+528
+00:55:41.972 --> 00:55:44.350
+- Over there. Just follow them.
+- Take cover.
+
+529
+00:55:48.078 --> 00:55:49.250
+She's stuck.
+
+530
+00:55:53.817 --> 00:55:55.694
+Hank's still in the car.
+
+531
+00:55:56.520 --> 00:55:57.555
+Hank's in the car.
+
+532
+00:55:58.422 --> 00:56:00.561
+- I'll get him, I'll get him.
+- No, no.
+
+533
+00:56:01.091 --> 00:56:03.332
+Get your mom to the overpass.
+
+534
+00:56:21.712 --> 00:56:23.521
+Hank! Hank! Come!
+
+535
+00:56:32.422 --> 00:56:33.628
+Jonathan!
+- Mom, ifs okay.
+
+536
+00:56:54.645 --> 00:56:56.090
+- Jonathan!
+- Mom, stay here.
+
+537
+00:57:21.905 --> 00:57:24.408
+Dad!
+
+538
+00:57:26.944 --> 00:57:30.016
+I let my father die because I trusted him.
+
+539
+00:57:30.914 --> 00:57:34.828
+Because he was convinced
+that I had to wait.
+
+540
+00:57:35.585 --> 00:57:37.758
+That the world was not ready.
+
+541
+00:57:39.489 --> 00:57:41.127
+What do you think?
+
+542
+00:57:46.029 --> 00:57:47.667
+You better watch out, Lois.
+
+543
+00:57:48.165 --> 00:57:50.475
+Hey, Perry's gunning for you.
+
+544
+00:57:50.701 --> 00:57:54.478
+He knows you're Woodburns anonymous
+source and cannot wait to rip you a new one.
+
+545
+00:57:56.840 --> 00:57:58.285
+Oh, look at her. Ha, ha, ha.
+
+546
+00:58:00.277 --> 00:58:02.814
+I told you not to run with this,
+and what do you do?
+
+547
+00:58:03.046 --> 00:58:05.549
+You let Wood burn just shotgun it
+all over the Internet.
+
+548
+00:58:05.816 --> 00:58:08.695
+Now the publishers want me to sue you.
+
+549
+00:58:08.952 --> 00:58:12.195
+Well, if it makes a difference,
+I'm dropping it.
+
+550
+00:58:12.456 --> 00:58:13.457
+Whoa, just like that?
+
+551
+00:58:13.690 --> 00:58:14.691
+Yep.
+
+552
+00:58:15.058 --> 00:58:16.366
+What happened to your leads?
+
+553
+00:58:17.027 --> 00:58:19.667
+They didn't pan out. The story is smoke.
+
+554
+00:58:19.896 --> 00:58:21.842
+Or it didn't get the traction you hoped?
+
+555
+00:58:24.201 --> 00:58:25.043
+Two weeks leave...
+
+556
+00:58:25.302 --> 00:58:26.906
+...no pay, that's your penance.
+
+557
+00:58:27.170 --> 00:58:28.843
+You try something like this again...
+
+558
+00:58:29.072 --> 00:58:30.745
+...you're done here.
+- Fine.
+
+559
+00:58:31.008 --> 00:58:33.716
+Let's make it three weeks
+since you're so willing to agree.
+
+560
+00:58:33.977 --> 00:58:35.479
+- Perry.
+- No, no. Don't. Don't.
+
+561
+00:58:37.147 --> 00:58:38.820
+I believe you saw something, Lois.
+
+562
+00:58:39.316 --> 00:58:42.320
+But not for a moment do I believe
+that your leads just went cold.
+
+563
+00:58:42.552 --> 00:58:46.056
+So whatever your reasons are
+for dropping it...
+
+564
+00:58:47.090 --> 00:58:48.933
+...I think you're doing the right thing.
+
+565
+00:58:49.493 --> 00:58:50.733
+Why?
+
+566
+00:58:52.095 --> 00:58:55.736
+Can you imagine how people
+on this planet would react...
+
+567
+00:58:58.001 --> 00:59:01.448
+...if they knew there was
+someone like this out there?
+
+568
+00:59:19.589 --> 00:59:20.590
+Go get him.
+
+569
+00:59:27.431 --> 00:59:29.069
+Well, look at you.
+
+570
+00:59:46.116 --> 00:59:47.925
+A reporter came by here.
+
+571
+00:59:48.485 --> 00:59:50.726
+She's a friend. Don't worry.
+
+572
+00:59:51.455 --> 00:59:52.798
+Oh.
+
+573
+00:59:53.723 --> 00:59:54.599
+Mom.
+
+574
+00:59:54.758 --> 00:59:56.499
+- Heh, heh, heh.
+- What'?
+
+575
+00:59:57.961 --> 01:00:00.498
+- I found them.
+- Who?
+
+576
+01:00:01.331 --> 01:00:02.833
+My parents.
+
+577
+01:00:04.000 --> 01:00:05.343
+My People.
+
+578
+01:00:06.236 --> 01:00:09.445
+I know where I come from now.
+
+579
+01:00:10.841 --> 01:00:12.115
+Wow.
+
+580
+01:00:13.176 --> 01:00:14.951
+That's wonderful.
+
+581
+01:00:16.813 --> 01:00:19.259
+I'm so happy for you, Clark.
+
+582
+01:00:28.091 --> 01:00:30.628
+What?
+- it's nothing.
+
+583
+01:00:33.330 --> 01:00:36.277
+When you were a baby I used to lay
+by your crib at night...
+
+584
+01:00:36.500 --> 01:00:38.878
+...listening to you breathe.
+
+585
+01:00:39.936 --> 01:00:41.540
+It was hard for you.
+
+586
+01:00:42.772 --> 01:00:44.149
+You struggled.
+
+587
+01:00:44.374 --> 01:00:46.217
+And I worried all the time.
+
+588
+01:00:46.476 --> 01:00:48.319
+You worried the truth would come out.
+
+589
+01:00:49.846 --> 01:00:51.052
+No.
+
+590
+01:00:52.015 --> 01:00:54.621
+The truth about you is beautiful.
+
+591
+01:00:55.051 --> 01:00:58.498
+We saw that the moment
+we laid eyes on you.
+
+592
+01:01:00.790 --> 01:01:04.795
+We knew that one day,
+the whole world would see that.
+
+593
+01:01:07.230 --> 01:01:08.868
+I'm just...
+
+594
+01:01:09.499 --> 01:01:11.570
+I'm worried they'll take you away from me.
+
+595
+01:01:13.803 --> 01:01:16.181
+I'm not going anywhere, Mom.
+
+596
+01:01:18.008 --> 01:01:19.510
+I promise.
+
+597
+01:01:25.715 --> 01:01:27.888
+General Swanwick, sir.
+
+598
+01:01:28.151 --> 01:01:31.894
+What am I looking at, doc?
+Comet? Asteroid?
+
+599
+01:01:33.056 --> 01:01:37.061
+Comets don't make
+course corrections, general.
+
+600
+01:01:39.863 --> 01:01:43.868
+Wanted you to see this before some amateur
+with a telescope creates a worldwide panic.
+
+601
+01:01:45.535 --> 01:01:46.912
+The ship appears to have...
+
+602
+01:01:47.170 --> 01:01:49.912
+...inserted itself into
+a lunar synchronous orbit...
+
+603
+01:01:50.173 --> 01:01:52.346
+...though I have no idea why.
+
+604
+01:01:52.576 --> 01:01:55.420
+Have you tried... communicating with it?
+
+605
+01:01:55.679 --> 01:01:59.684
+Well, they haven't responded as of yet.
+
+606
+01:02:00.951 --> 01:02:04.956
+I'm just speculating, but I think
+whoever? at the helm of that thing...
+
+607
+01:02:05.222 --> 01:02:07.725
+...is looking to make a dramatic entrance.
+
+608
+01:02:14.598 --> 01:02:16.043
+Anybody know where we keep the toner?
+
+609
+01:02:17.033 --> 01:02:18.944
+- What's going on?
+- it's all over the news.
+
+610
+01:02:19.202 --> 01:02:21.148
+You gotta see this.
+
+611
+01:02:48.131 --> 01:02:49.633
+Clark.
+
+612
+01:02:50.000 --> 01:02:51.138
+Yeah?
+
+613
+01:02:51.401 --> 01:02:52.744
+Coming.
+
+614
+01:02:53.069 --> 01:02:55.106
+This is a breaking news. An unidentified...
+
+615
+01:03:36.980 --> 01:03:39.051
+You are not alone.
+
+616
+01:03:40.717 --> 01:03:43.061
+You are not alone.
+
+617
+01:03:44.988 --> 01:03:47.229
+You are not alone.
+
+618
+01:03:52.896 --> 01:03:55.502
+You are not alone.
+
+619
+01:04:20.924 --> 01:04:22.426
+It's coming in on the RSS feeds.
+
+620
+01:04:22.692 --> 01:04:24.569
+You are not alone.
+
+621
+01:04:25.195 --> 01:04:27.232
+It's on my phone too.
+
+622
+01:04:29.399 --> 01:04:31.845
+My name is General Zod.
+
+623
+01:04:33.670 --> 01:04:36.446
+Icome from a world far from yours.
+
+624
+01:04:37.841 --> 01:04:41.846
+I have journeyed across
+an ocean of stars to reach you.
+
+625
+01:04:43.947 --> 01:04:47.952
+For some time, your world
+has sheltered one of my citizens.
+
+626
+01:04:48.585 --> 01:04:51.794
+I request that you return this individual...
+
+627
+01:04:52.055 --> 01:04:54.194
+...to my custody.
+
+628
+01:04:54.424 --> 01:04:58.429
+For reasons unknown,
+he has chosen to keep his existence...
+
+629
+01:04:58.695 --> 01:05:00.538
+...a secret from you.
+
+630
+01:05:01.598 --> 01:05:04.772
+He will have made efforts to blend in.
+
+631
+01:05:05.368 --> 01:05:07.041
+He will look like you.
+
+632
+01:05:07.771 --> 01:05:10.377
+But he is not one of you.
+
+633
+01:05:11.574 --> 01:05:13.417
+To those of you who may know...
+
+634
+01:05:13.643 --> 01:05:15.645
+...of his current location...
+
+635
+01:05:15.912 --> 01:05:18.449
+mine fare of your planer."...
+
+636
+01:05:18.715 --> 01:05:21.389
+...rests in your hands.
+
+637
+01:05:22.452 --> 01:05:25.490
+To Kai-El, <i>I</i> say this:
+
+638
+01:05:27.557 --> 01:05:30.231
+Surrender within 24 hours...
+
+639
+01:05:34.497 --> 01:05:37.478
+...or watch this world
+suffer the consequences.
+
+640
+01:05:41.404 --> 01:05:42.075
+Ah!
+
+641
+01:05:53.249 --> 01:05:55.092
+We hardly know anything
+about him, isn't that right?
+
+642
+01:05:55.251 --> 01:05:57.253
+If he truly means us no harm...
+
+643
+01:05:57.487 --> 01:05:59.489
+...he'll turn himself in
+and face the consequences.
+
+644
+01:06:00.123 --> 01:06:01.329
+And if he won't do that...
+
+645
+01:06:01.591 --> 01:06:03.593
+...then maybe we should.
+
+646
+01:06:03.827 --> 01:06:06.808
+The Daily Planet's Lois Lane
+knows who this guy is. Shek...
+
+647
+01:06:07.030 --> 01:06:07.940
+...the one we should
+be questioning.
+
+648
+01:06:08.932 --> 01:06:11.674
+- Hold on. You're saying Lois Lane--
+- Hello?
+
+649
+01:06:11.935 --> 01:06:14.438
+Are you watching this crap?
+Been running all morning.
+
+650
+01:06:14.671 --> 01:06:16.981
+For once I agree with Woodburn.
+Have you seen him?
+
+651
+01:06:17.207 --> 01:06:20.518
+- Do you know where he is?
+- No. Even if I did, I wouldn't say.
+
+652
+01:06:20.777 --> 01:06:23.951
+The entire world is being threatened here.
+
+653
+01:06:24.180 --> 01:06:25.818
+This is not time for you to fall...
+
+654
+01:06:26.049 --> 01:06:28.393
+...back on journalistic integrity.
+
+655
+01:06:28.651 --> 01:06:30.130
+This is serious, Lois.
+
+656
+01:06:30.353 --> 01:06:33.334
+The FBI is here. They're throwing around
+words like "treason."
+
+657
+01:06:33.556 --> 01:06:35.229
+I gotta go-
+
+658
+01:06:51.374 --> 01:06:52.717
+FBI. Hands up.
+
+659
+01:06:52.976 --> 01:06:54.751
+Drop the bag. Now.
+
+660
+01:07:01.651 --> 01:07:03.892
+Regarding the visitors
+themselves we know...
+
+661
+01:07:04.153 --> 01:07:06.599
+very little.
+According to government officials...
+
+662
+01:07:06.856 --> 01:07:09.336
+...the visitors do not represent a threat...
+
+663
+01:07:09.559 --> 01:07:11.732
+<i>despite the ominous tone</i>
+<i>of their message.</i>
+
+664
+01:07:11.995 --> 01:07:14.498
+Then of course there's the question
+on everyonek mind:
+
+665
+01:07:14.731 --> 01:07:18.543
+"Who is this Kal-El person?
+Does he actually exist?
+
+666
+01:07:18.768 --> 01:07:21.442
+How could he have remained
+hidden from us for so long?"
+
+667
+01:07:26.075 --> 01:07:27.383
+Come on, Kent.
+
+668
+01:07:34.450 --> 01:07:35.554
+Come on. Fight back.
+
+669
+01:07:35.785 --> 01:07:37.389
+Get up, Kent.
+
+670
+01:07:40.690 --> 01:07:42.067
+So is that it?
+
+671
+01:07:42.525 --> 01:07:44.027
+Is that all you've got?
+
+672
+01:07:45.695 --> 01:07:47.197
+Come on, Kent.
+
+673
+01:07:48.431 --> 01:07:49.808
+Come on!
+
+674
+01:08:18.428 --> 01:08:19.566
+Did they hurl you?
+
+675
+01:08:20.830 --> 01:08:22.241
+You know they can't.
+
+676
+01:08:22.599 --> 01:08:25.478
+That's not what I meant.
+I meant, are you all right?
+
+677
+01:08:27.470 --> 01:08:29.780
+I wanted to hit that kid.
+I wanted to hit him bad.
+
+678
+01:08:30.006 --> 01:08:31.485
+I know you did. I mean...
+
+679
+01:08:31.741 --> 01:08:34.449
+...part of me even wanted you to,
+but then what?
+
+680
+01:08:35.144 --> 01:08:36.316
+Make you feel any better?
+
+681
+01:08:39.682 --> 01:08:43.687
+You just have to decide what kind of man
+you want to grow up to be, Clark.
+
+682
+01:08:43.953 --> 01:08:47.662
+Because whoever that man is,
+good character or bad, he's...
+
+683
+01:08:49.292 --> 01:08:51.431
+He's gonna change the world.
+
+684
+01:08:56.666 --> 01:08:57.701
+What's on your mind?
+
+685
+01:09:03.773 --> 01:09:05.047
+I don't know where to start.
+
+686
+01:09:05.675 --> 01:09:07.279
+Wherever you want.
+
+687
+01:09:09.445 --> 01:09:11.550
+That ship that appeared last night.
+
+688
+01:09:12.882 --> 01:09:14.691
+I'm the one they're looking for.
+
+689
+01:09:19.188 --> 01:09:20.690
+Do you know...
+
+690
+01:09:21.491 --> 01:09:22.629
+...why they want you?
+
+691
+01:09:22.859 --> 01:09:25.465
+No. But this General Zod...
+
+692
+01:09:25.695 --> 01:09:29.700
+...even if I surrender, there's no guarantee
+he'll keep his word, but...
+
+693
+01:09:29.966 --> 01:09:33.971
+...if there's a chance I can save Earth
+by turning myself in...
+
+694
+01:09:35.571 --> 01:09:36.709
+...shouldn't I take it'?
+
+695
+01:09:38.207 --> 01:09:40.084
+What does your gut tell you?
+
+696
+01:09:40.810 --> 01:09:42.517
+Zod can't be trusted.
+
+697
+01:09:45.148 --> 01:09:46.718
+The problem is...
+
+698
+01:09:47.750 --> 01:09:50.356
+...I'm not sure the people of Earth
+can be either.
+
+699
+01:09:58.361 --> 01:10:01.342
+Sometimes you have to take
+a leap of faith first.
+
+700
+01:10:02.732 --> 01:10:04.769
+The trust part comes later.
+
+701
+01:10:28.925 --> 01:10:31.633
+All right. You've got our attention.
+
+702
+01:10:32.128 --> 01:10:33.129
+What is it you want?
+
+703
+01:10:33.396 --> 01:10:35.205
+I would like to speak to Lois Lane.
+
+704
+01:10:35.431 --> 01:10:36.705
+What makes you think she's here?
+
+705
+01:10:37.633 --> 01:10:39.704
+Don't play games with me, general.
+
+706
+01:10:39.936 --> 01:10:43.941
+I'll surrender, but only if you
+guarantee Lois's freedom.
+
+707
+01:10:54.050 --> 01:10:55.996
+Why are you surrendering to Zod?
+
+708
+01:10:57.220 --> 01:11:00.827
+I'm surrendering to mankind.
+There's a difference.
+
+709
+01:11:01.958 --> 01:11:03.904
+You let them handcuff you?
+
+710
+01:11:04.627 --> 01:11:07.073
+Wouldn't be much of a surrender
+if I resisted.
+
+711
+01:11:08.564 --> 01:11:10.601
+And if it makes them feel more secure...
+
+712
+01:11:11.667 --> 01:11:13.510
+...then all the better for it.
+
+713
+01:11:17.940 --> 01:11:19.112
+What's the S stand for?
+
+714
+01:11:22.745 --> 01:11:24.315
+It's not an S.
+
+715
+01:11:25.782 --> 01:11:27.352
+On my world it means hope.
+
+716
+01:11:29.318 --> 01:11:32.822
+Well, here, it's an S.
+
+717
+01:11:34.857 --> 01:11:36.427
+How about...
+
+718
+01:11:40.763 --> 01:11:41.764
+...Super--
+
+719
+01:11:41.998 --> 01:11:43.033
+Sir?
+
+720
+01:11:43.299 --> 01:11:46.644
+- Hi, my name is Dr. E--
+Emil Hamilton.
+
+721
+01:11:46.869 --> 01:11:49.850
+I know, I can see your ID tag
+in your breast pocket.
+
+722
+01:11:50.106 --> 01:11:52.143
+Along with a half-eaten roll of Lifesavers.
+
+723
+01:11:53.309 --> 01:11:55.653
+I can also see the soldiers
+in the next room...
+
+724
+01:11:55.878 --> 01:11:58.188
+...preparing that tranquilizing agent
+of yours.
+
+725
+01:11:58.447 --> 01:11:59.892
+You won't need it.
+
+726
+01:12:00.149 --> 01:12:03.187
+Sir, you can't expect us
+to not take precautions.
+
+727
+01:12:03.452 --> 01:12:05.864
+You could be carrying
+some kind of alien pathogen.
+
+728
+01:12:06.122 --> 01:12:07.567
+Been here for 33 years, doctor.
+
+729
+01:12:07.824 --> 01:12:11.738
+- Haven't infected anyone yet.
+- That you know of. We have legitimate...
+
+730
+01:12:11.994 --> 01:12:15.373
+...security concerns. You revealed
+your identity to Miss Lane over there.
+
+731
+01:12:16.365 --> 01:12:18.572
+Why won't you do the same with us?
+
+732
+01:12:19.535 --> 01:12:21.879
+Let's put our cards on the table here,
+general.
+
+733
+01:12:23.339 --> 01:12:25.046
+You're scared because you can't control me.
+
+734
+01:12:25.641 --> 01:12:28.178
+You don't, and you never will.
+
+735
+01:12:29.011 --> 01:12:30.991
+But that doesn' mean I'm your enemy.
+
+736
+01:12:31.214 --> 01:12:32.716
+Then who is'?
+
+737
+01:12:32.982 --> 01:12:34.393
+Zod'?
+
+738
+01:12:35.017 --> 01:12:36.428
+That's what I'm worried about.
+
+739
+01:12:37.019 --> 01:12:38.726
+Be that as it may...
+
+740
+01:12:38.988 --> 01:12:41.764
+...I've been given orders
+to hand you over to him.
+
+741
+01:12:42.992 --> 01:12:44.869
+Do what you have to do, general.
+
+742
+01:12:49.665 --> 01:12:50.439
+Thank you.
+
+743
+01:12:51.567 --> 01:12:52.545
+For what?
+
+744
+01:12:53.703 --> 01:12:55.273
+For believing in me.
+
+745
+01:12:58.341 --> 01:13:00.378
+Didn't make much difference in the end.
+
+746
+01:13:01.210 --> 01:13:02.746
+It did to me.
+
+747
+01:13:23.366 --> 01:13:24.902
+They're coming.
+
+748
+01:13:25.701 --> 01:13:27.203
+You should leave now.
+
+749
+01:13:30.306 --> 01:13:31.876
+Go, Lois.
+
+750
+01:14:42.778 --> 01:14:44.155
+Kai-El.
+
+751
+01:14:44.680 --> 01:14:46.717
+I'm sub-commander Faora-Ul.
+
+752
+01:14:47.383 --> 01:14:50.660
+On behalf of General Zod,
+I extend you his greetings.
+
+753
+01:14:56.692 --> 01:14:59.798
+- Are you the ranking officer here?
+- I am.
+
+754
+01:15:00.029 --> 01:15:02.009
+General Zod would like this woman...
+
+755
+01:15:02.231 --> 01:15:03.869
+...to accompany me.
+
+756
+01:15:04.834 --> 01:15:05.972
+You asked for the alien.
+
+757
+01:15:07.403 --> 01:15:10.350
+You didn't say anything
+about one of our own.
+
+758
+01:15:10.573 --> 01:15:13.713
+Shall I tell the general
+you're unwilling to comply?
+
+759
+01:15:13.976 --> 01:15:15.853
+I don't care what you tell him.
+
+760
+01:15:18.848 --> 01:15:20.259
+It's all right.
+
+761
+01:15:21.350 --> 01:15:22.556
+I'll go.
+
+762
+01:16:05.394 --> 01:16:09.240
+The atmospheric composition on our ship
+is not compatible with humans.
+
+763
+01:16:09.465 --> 01:16:10.876
+You need to wear a breather...
+
+764
+01:16:11.100 --> 01:16:12.773
+...beyond this point.
+
+765
+01:16:37.927 --> 01:16:38.837
+Kai-El.
+
+766
+01:16:40.796 --> 01:16:42.434
+You have no idea how long...
+
+767
+01:16:42.665 --> 01:16:44.736
+...we've been searching for you.
+
+768
+01:16:45.167 --> 01:16:46.168
+I take it you're Zod?
+
+769
+01:16:46.435 --> 01:16:47.573
+General Zod.
+
+770
+01:16:47.803 --> 01:16:49.612
+- Our commander.
+- it's all right, Faora.
+
+771
+01:16:49.839 --> 01:16:52.513
+We can forgive Kal any lapses in decorum.
+
+772
+01:16:52.775 --> 01:16:54.686
+He's a stranger to our ways.
+
+773
+01:16:54.944 --> 01:16:55.979
+This should be cause...
+
+774
+01:16:56.245 --> 01:16:59.283
+...for celebration, not conflict.
+
+775
+01:16:59.515 --> 01:17:01.688
+- Unh.
+- Not conflict.
+
+776
+01:17:04.120 --> 01:17:05.155
+I...
+
+777
+01:17:05.421 --> 01:17:06.627
+...feel strange.
+
+778
+01:17:09.358 --> 01:17:10.666
+Weak.
+
+779
+01:17:12.862 --> 01:17:14.000
+What's happening to him?
+
+780
+01:17:14.263 --> 01:17:16.800
+He's rejecting our ship's atmospherics.
+
+781
+01:17:17.032 --> 01:17:17.635
+Clark.
+
+782
+01:17:17.867 --> 01:17:20.541
+You've spent a lifetime
+adapting to Earth's ecology...
+
+783
+01:17:20.703 --> 01:17:21.647
+...but never adapted to ours.
+
+784
+01:17:21.804 --> 01:17:22.839
+Help him.
+
+785
+01:17:23.105 --> 01:17:24.641
+I can't. Whatever's happening...
+
+786
+01:17:24.874 --> 01:17:27.115
+- ...has to run its course.
+- Clark.
+
+787
+01:17:28.477 --> 01:17:29.785
+Help him.
+
+788
+01:17:31.547 --> 01:17:32.719
+Help him.
+
+789
+01:17:44.360 --> 01:17:45.896
+Hello, Kal.
+
+790
+01:17:47.563 --> 01:17:48.633
+Or do you prefer Clark?
+
+791
+01:17:50.366 --> 01:17:51.743
+That's the name they gave you.
+
+792
+01:17:52.001 --> 01:17:53.309
+Isn't it?
+
+793
+01:17:54.570 --> 01:17:56.311
+I was Krypton's military leader...
+
+794
+01:17:56.539 --> 01:17:58.985
+...your father our foremost scientist.
+
+795
+01:17:59.208 --> 01:18:00.653
+The only thing we agreed on...
+
+796
+01:18:00.876 --> 01:18:03.652
+...was that Krypton was dying.
+In return for my efforts...
+
+797
+01:18:03.879 --> 01:18:06.416
+...to protect our civilization...
+
+798
+01:18:06.682 --> 01:18:08.753
+...and save our planet...
+
+799
+01:18:09.018 --> 01:18:13.023
+...I and my fellow officers
+were sentenced to the Phantom Zone.
+
+800
+01:18:15.991 --> 01:18:19.234
+And then the destruction of our world...
+
+801
+01:18:19.495 --> 01:18:20.997
+...freed us.
+
+802
+01:18:26.168 --> 01:18:29.672
+We were adrift, destined to ﬂoat...
+
+803
+01:18:29.905 --> 01:18:31.851
+"amongst the ruins of our planet...
+
+804
+01:18:32.074 --> 01:18:33.951
+...until we starved.
+
+805
+01:18:34.843 --> 01:18:36.447
+How did you find your way to Earth?
+
+806
+01:18:37.213 --> 01:18:41.218
+We managed to retrofit
+the phantom projector into a hyperdrive.
+
+807
+01:18:41.717 --> 01:18:44.891
+Your father made a similar modification
+to the craft that brought you here.
+
+808
+01:18:46.922 --> 01:18:50.028
+And so the instrument of our damnation...
+
+809
+01:18:52.061 --> 01:18:53.870
+...became our salvation.
+
+810
+01:18:58.801 --> 01:19:01.304
+We sought out the old colonial outposts...
+
+811
+01:19:01.570 --> 01:19:03.777
+...looking for signs of life.
+
+812
+01:19:06.242 --> 01:19:09.052
+But all we found was death.
+
+813
+01:19:10.045 --> 01:19:12.616
+Cut off from Krypton, these outposts...
+
+814
+01:19:12.881 --> 01:19:15.088
+mwithered and died long ago.
+
+815
+01:19:15.584 --> 01:19:17.564
+We salvaged what we could...
+
+816
+01:19:17.786 --> 01:19:19.493
+...3!'H? Of', “weapons...
+
+817
+01:19:19.755 --> 01:19:21.666
+...even a world engine.
+
+818
+01:19:23.425 --> 01:19:25.302
+For 33 years we prepared...
+
+819
+01:19:26.795 --> 01:19:29.571
+...until finally we detected
+a distress beacon...
+
+820
+01:19:29.798 --> 01:19:31.607
+...which you triggered...
+
+821
+01:19:31.834 --> 01:19:34.075
+...when you accessed
+the ancient scout ship.
+
+822
+01:19:35.471 --> 01:19:38.008
+You led us here, Kal.
+
+823
+01:19:39.141 --> 01:19:40.484
+Now it's within your power...
+
+824
+01:19:40.743 --> 01:19:44.350
+...to save what remains of your race.
+
+825
+01:19:49.118 --> 01:19:50.358
+On Krypton...
+
+826
+01:19:50.619 --> 01:19:53.259
+...the genetic template
+for every being yet to be born...
+
+827
+01:19:53.489 --> 01:19:56.026
+...is encoded in the registry of citizens.
+
+828
+01:19:56.692 --> 01:19:58.831
+Your father stole the registry's Codex...
+
+829
+01:19:59.094 --> 01:20:01.938
+...and stored it in the capsule
+that brought you here.
+
+830
+01:20:02.631 --> 01:20:03.473
+For what purpose?
+
+831
+01:20:04.533 --> 01:20:07.275
+So that Krypton can live again...
+
+832
+01:20:08.137 --> 01:20:09.673
+...on Earth.
+
+833
+01:20:29.525 --> 01:20:31.630
+Where is the Codex, Kal?
+
+834
+01:20:33.295 --> 01:20:35.138
+If Krypton lives again...
+
+835
+01:20:36.298 --> 01:20:37.675
+...what happens to Earth?
+
+836
+01:20:38.701 --> 01:20:42.205
+The foundation has to be
+built on something.
+
+837
+01:20:42.471 --> 01:20:45.247
+Even your father recognized that.
+
+838
+01:20:51.714 --> 01:20:54.024
+No, Zod.
+
+839
+01:20:55.184 --> 01:20:56.390
+I can't be a part of this.
+
+840
+01:20:57.219 --> 01:20:58.926
+Then what can you be a part of?
+
+841
+01:20:59.521 --> 01:21:00.727
+No!
+
+842
+01:21:01.924 --> 01:21:02.527
+Zod!
+
+843
+01:21:04.026 --> 01:21:04.731
+No!
+
+844
+01:21:05.894 --> 01:21:07.532
+No!
+
+845
+01:21:13.569 --> 01:21:14.707
+Your father acquitted...
+
+846
+01:21:14.937 --> 01:21:16.939
+...himself with honor, Kal.
+
+847
+01:21:19.842 --> 01:21:21.788
+You killed him?
+
+848
+01:21:22.177 --> 01:21:23.520
+I did.
+
+849
+01:21:24.113 --> 01:21:27.526
+And not a day goes by
+where it doesn't haunt me.
+
+850
+01:21:28.884 --> 01:21:31.228
+But if I had to do it again, I would.
+
+851
+01:21:31.453 --> 01:21:34.923
+I have a duty to my people...
+
+852
+01:21:35.190 --> 01:21:39.195
+...and I will not allow anyone
+to prevent me from carrying it out.
+
+853
+01:21:55.644 --> 01:21:57.282
+What's the sit-rep, major?
+
+854
+01:21:57.913 --> 01:22:00.291
+DSP pinged two bogeys
+launching from the alien ship.
+
+855
+01:22:00.549 --> 01:22:02.654
+- Put it up.
+- Yes, sir.
+
+856
+01:22:03.085 --> 01:22:04.155
+There it is.
+
+857
+01:22:04.420 --> 01:22:05.228
+Re-task lkon-4...
+
+858
+01:22:05.454 --> 01:22:07.900
+- ...and get me a closer look.
+- Yes, sir.
+
+859
+01:22:08.223 --> 01:22:09.133
+Command, the word...
+
+860
+01:22:09.391 --> 01:22:10.563
+...of the day is trident.
+
+861
+01:22:10.793 --> 01:22:12.898
+We have two alien craft
+on aggressive approach.
+
+862
+01:22:13.128 --> 01:22:14.766
+Ikon-4 coming online.
+
+863
+01:22:14.997 --> 01:22:15.805
+Air speed?
+
+864
+01:22:16.064 --> 01:22:17.475
+380 knots, entering Kansas...
+
+865
+01:22:17.733 --> 01:22:19.735
+...airspace.
+Not responding to our hails.
+
+866
+01:22:19.968 --> 01:22:22.175
+You're wasting your efforts.
+
+867
+01:22:23.105 --> 01:22:25.449
+The strength you derived
+from the Earth's sun...
+
+868
+01:22:25.674 --> 01:22:27.779
+...has been neutralized aboard our ship.
+
+869
+01:22:28.444 --> 01:22:29.582
+Here...
+
+870
+01:22:29.812 --> 01:22:31.416
+...in this environment...
+
+871
+01:22:32.181 --> 01:22:33.660
+...you are as weak as a human.
+
+872
+01:22:36.251 --> 01:22:37.161
+Unh!
+
+873
+01:22:41.123 --> 01:22:42.261
+Unh!
+
+874
+01:23:32.207 --> 01:23:34.050
+Where did you come from?
+
+875
+01:23:34.576 --> 01:23:36.021
+The command key, Miss Lane.
+
+876
+01:23:36.245 --> 01:23:38.691
+Thanks to you, I'm uploading
+to the ship's mainframe.
+
+877
+01:23:39.915 --> 01:23:40.893
+Who are you?
+
+878
+01:23:41.850 --> 01:23:43.158
+I am Kai's father.
+
+879
+01:23:44.820 --> 01:23:45.560
+Can you help us?
+
+880
+01:23:47.523 --> 01:23:49.366
+I designed this ship.
+
+881
+01:23:49.591 --> 01:23:51.764
+I can modify its atmospheric composition...
+
+882
+01:23:52.027 --> 01:23:53.768
+...to human compatibility.
+
+883
+01:23:54.029 --> 01:23:54.871
+We can stop them.
+
+884
+01:23:55.097 --> 01:23:57.577
+We can send them back
+to the Phantom Zone.
+
+885
+01:23:58.534 --> 01:23:59.171
+How?
+
+886
+01:23:59.401 --> 01:24:00.937
+I can teach you.
+
+887
+01:24:01.203 --> 01:24:03.012
+And in turn, you can teach Kal.
+
+888
+01:24:03.238 --> 01:24:04.945
+Will you help me?
+
+889
+01:24:18.787 --> 01:24:20.095
+The ship's crew are alerted.
+
+890
+01:24:20.355 --> 01:24:21.390
+We need to move quickly.
+
+891
+01:24:21.623 --> 01:24:23.296
+Retrieve the command key.
+
+892
+01:24:30.933 --> 01:24:33.971
+- Did you do that?
+- Yes. Pick up her sidearm.
+
+893
+01:24:43.378 --> 01:24:44.755
+What's happening?
+
+894
+01:25:05.734 --> 01:25:06.405
+To your right.
+
+895
+01:25:06.635 --> 01:25:07.272
+Fire.
+
+896
+01:25:08.837 --> 01:25:09.577
+Behind you.
+
+897
+01:25:23.085 --> 01:25:25.122
+Secure yourself inside the open pod.
+
+898
+01:25:26.154 --> 01:25:28.430
+Safe travels, Miss Lane. It's unlikely...
+
+899
+01:25:28.657 --> 01:25:30.261
+...we'll see each other again.
+
+900
+01:25:31.827 --> 01:25:34.933
+Remember, the phantom drives
+are essential in stopping them.
+
+901
+01:25:35.797 --> 01:25:37.037
+Move your head to the left.
+
+902
+01:26:04.626 --> 01:26:06.537
+Is it true what Zod said about the Codex?
+
+903
+01:26:07.663 --> 01:26:09.040
+Strike that panel.
+
+904
+01:26:12.701 --> 01:26:13.873
+We wanted you to learn...
+
+905
+01:26:14.136 --> 01:26:16.241
+...what it meant to be human first...
+
+906
+01:26:16.872 --> 01:26:20.513
+...so that one day, when the time was right,
+you could be the bridge...
+
+907
+01:26:20.742 --> 01:26:22.517
+...between two peoples.
+
+908
+01:26:25.247 --> 01:26:26.021
+Look.
+
+909
+01:26:29.184 --> 01:26:30.424
+Lois.
+
+910
+01:26:31.019 --> 01:26:32.054
+You can save her, Kal.
+
+911
+01:26:35.190 --> 01:26:37.067
+You can save all of them.
+
+912
+01:27:55.971 --> 01:27:57.507
+You'll be safe here.
+
+913
+01:27:59.841 --> 01:28:02.412
+- Are you all right?
+- Yeah.
+
+914
+01:28:05.647 --> 01:28:07.126
+I'm sorry.
+
+915
+01:28:07.849 --> 01:28:10.830
+I didn't wanna tell them anything,
+but they did something to me.
+
+916
+01:28:11.086 --> 01:28:13.259
+- They looked inside my mind--
+- it's okay, Lois.
+
+917
+01:28:13.488 --> 01:28:15.263
+They did the same thing to me.
+
+918
+01:28:28.336 --> 01:28:29.679
+Clark!
+
+919
+01:28:38.680 --> 01:28:40.455
+The craft he arrived in...
+
+920
+01:28:40.982 --> 01:28:42.154
+...where is it?
+
+921
+01:28:44.052 --> 01:28:45.224
+Go to hell.
+
+922
+01:28:56.531 --> 01:28:57.509
+There.
+
+923
+01:28:58.900 --> 01:28:59.571
+Unh!
+
+924
+01:29:20.522 --> 01:29:22.661
+The Codex is not here.
+
+925
+01:29:23.758 --> 01:29:25.032
+Argh!
+
+926
+01:29:26.094 --> 01:29:27.596
+Ah!
+
+927
+01:29:29.397 --> 01:29:30.432
+Where has he hidden it?
+
+928
+01:29:30.699 --> 01:29:31.336
+I don't know.
+
+929
+01:29:31.566 --> 01:29:32.670
+Where is the Codex?!
+
+930
+01:29:36.705 --> 01:29:38.048
+Ahh!
+
+931
+01:29:48.683 --> 01:29:50.629
+You think you can threaten my mother?!
+
+932
+01:29:56.224 --> 01:29:57.225
+Ah!
+
+933
+01:30:32.427 --> 01:30:33.906
+What have you done to me?
+
+934
+01:30:34.129 --> 01:30:36.575
+My parents taught me to hone...
+
+935
+01:30:36.798 --> 01:30:38.277
+...my senses, Zod.
+
+936
+01:30:39.968 --> 01:30:41.572
+Focus...
+
+937
+01:30:42.137 --> 01:30:43.844
+...on just what I wanted to see.
+
+938
+01:30:44.105 --> 01:30:45.140
+Without your helmet...
+
+939
+01:30:45.407 --> 01:30:46.977
+...you're getting everything.
+
+940
+01:30:47.175 --> 01:30:48.085
+Unh!
+
+941
+01:30:48.243 --> 01:30:49.654
+And it hurts...
+
+942
+01:30:50.245 --> 01:30:51.622
+...doesn't it?
+
+943
+01:31:02.490 --> 01:31:03.992
+Argh!
+
+944
+01:31:36.458 --> 01:31:37.732
+Get away from the window.
+
+945
+01:31:40.695 --> 01:31:42.504
+Get inside. It's not safe.
+
+946
+01:31:47.836 --> 01:31:50.715
+Ail players, this is
+Guardian. I am airborne mission commander.
+
+947
+01:31:50.972 --> 01:31:53.009
+I have previously encountered
+and observed...
+
+948
+01:31:53.241 --> 01:31:55.380
+...the beings we're about to engage.
+
+949
+01:31:55.643 --> 01:31:58.351
+They are extremely dangerous
+and we have been authorized...
+
+950
+01:31:58.580 --> 01:32:00.082
+...to use deadly force.
+
+951
+01:32:02.050 --> 01:32:04.030
+Roger, Guardian, we are inbound to target.
+
+952
+01:32:09.691 --> 01:32:10.897
+Cleared hot. Weapons free.
+
+953
+01:32:11.159 --> 01:32:12.763
+Copy, 11. Weapons free.
+
+954
+01:32:15.563 --> 01:32:16.337
+Thunder 11...
+
+955
+01:32:16.564 --> 01:32:17.599
+...tally three targets.
+
+956
+01:32:29.077 --> 01:32:30.112
+Unh!
+
+957
+01:32:35.216 --> 01:32:36.024
+Thunder 11...
+
+958
+01:32:36.251 --> 01:32:38.697
+...good hit.
+Request immediate re-attack.
+
+959
+01:32:38.920 --> 01:32:41.059
+Roger, Guardian.
+We'll make a second gun run...
+
+960
+01:32:41.289 --> 01:32:43.394
+...on a heading of 212 degrees.
+
+961
+01:32:50.398 --> 01:32:51.376
+Thunder 11, eject!
+
+962
+01:32:51.599 --> 01:32:52.976
+Eject!
+
+963
+01:32:53.301 --> 01:32:54.939
+Thunder 11, eject!
+
+964
+01:33:05.080 --> 01:33:06.650
+I have a bogey incoming!
+
+965
+01:33:07.482 --> 01:33:08.927
+Oh, shit.
+
+966
+01:33:23.832 --> 01:33:24.572
+Argh!
+
+967
+01:33:27.102 --> 01:33:27.978
+You are weak...
+
+968
+01:33:28.236 --> 01:33:29.340
+...son of El.
+
+969
+01:33:29.604 --> 01:33:30.742
+Unsure of yourself.
+
+970
+01:33:35.977 --> 01:33:38.958
+The fact that you possess
+a sense of morality...
+
+971
+01:33:39.180 --> 01:33:40.955
+...and we do not...
+
+972
+01:33:41.182 --> 01:33:43.753
+...gives us an evolutionary advantage.
+
+973
+01:33:47.255 --> 01:33:49.758
+And if history has proven anything...
+
+974
+01:33:59.634 --> 01:34:03.207
+...it is that evolution always wins.
+
+975
+01:34:04.873 --> 01:34:05.544
+Ragh!
+
+976
+01:34:10.311 --> 01:34:11.483
+Unh!
+
+977
+01:34:24.526 --> 01:34:26.028
+CCT, we're approaching...
+
+978
+01:34:26.294 --> 01:34:28.137
+...LZ Jayhawk. Get down in five.
+
+979
+01:34:28.363 --> 01:34:30.206
+Let's go. Go to the LZ.
+
+980
+01:34:30.999 --> 01:34:32.171
+Roger, sarge. let's go!
+
+981
+01:35:09.771 --> 01:35:11.079
+All rangers, I need you...
+
+982
+01:35:11.339 --> 01:35:12.511
+...to engage the targets.
+
+983
+01:35:13.007 --> 01:35:14.077
+Guardian, this is Badger 01.
+
+984
+01:35:14.342 --> 01:35:15.616
+What about the guy in blue?
+
+985
+01:35:15.877 --> 01:35:16.912
+I said engage...
+
+986
+01:35:17.178 --> 01:35:18.350
+...all targets.
+
+987
+01:35:29.524 --> 01:35:30.559
+Contact. Contact.
+
+988
+01:35:34.929 --> 01:35:35.805
+Ah!
+
+989
+01:35:40.735 --> 01:35:41.577
+You Okay?
+
+990
+01:35:47.308 --> 01:35:49.413
+We're auto-rotating, going in hard.
+
+991
+01:35:50.144 --> 01:35:51.316
+Brace for impact.
+
+992
+01:35:52.113 --> 01:35:53.251
+Brace for impact.
+
+993
+01:35:53.481 --> 01:35:54.459
+We're going in hard!
+
+994
+01:35:59.554 --> 01:36:03.559
+Fallen angel. Fallen angel.
+Guardian is down. I repeat, Guardian is down.
+
+995
+01:36:25.480 --> 01:36:26.982
+Guardian, do you read?
+
+996
+01:36:27.248 --> 01:36:28.591
+Thunder 12, calling Guardian.
+
+997
+01:36:28.816 --> 01:36:30.159
+- Do you read?
+- Thunder 12...
+
+998
+01:36:30.418 --> 01:36:31.328
+...this is Guardian.
+
+999
+01:36:31.586 --> 01:36:33.964
+Put down everything you've got
+north of my position.
+
+1000
+01:36:34.188 --> 01:36:36.361
+- This will be danger-close.
+- Copy, danger-close.
+
+1001
+01:36:36.624 --> 01:36:37.864
+Good luck, sir.
+
+1002
+01:37:17.732 --> 01:37:20.576
+A good death is its own reward.
+
+1003
+01:37:34.182 --> 01:37:35.559
+You will not win.
+
+1004
+01:37:36.984 --> 01:37:38.520
+For every human you save...
+
+1005
+01:37:38.753 --> 01:37:41.427
+...we will kill a million more. Unh!
+
+1006
+01:38:32.740 --> 01:38:35.914
+Do we have an all clear?
+Do we have an all clear?
+
+1007
+01:38:36.144 --> 01:38:38.420
+Alpha team, sit-rep. Alpha team.
+
+1008
+01:38:38.646 --> 01:38:40.250
+Do you copy? Alpha team.
+
+1009
+01:39:29.764 --> 01:39:31.971
+This man is not our enemy.
+
+1010
+01:39:34.435 --> 01:39:35.971
+Thank you, colonel.
+
+1011
+01:39:53.821 --> 01:39:54.663
+Mom'?
+
+1012
+01:39:55.957 --> 01:39:57.630
+I'm all right.
+
+1013
+01:40:09.670 --> 01:40:11.650
+Nice suit, son.
+
+1014
+01:40:12.707 --> 01:40:14.015
+I'm so sorry.
+
+1015
+01:40:15.042 --> 01:40:17.352
+It's only stuff, Clark.
+
+1016
+01:40:18.513 --> 01:40:20.925
+It can always be replaced.
+
+1017
+01:40:23.384 --> 01:40:24.658
+But you can't be.
+
+1018
+01:40:25.987 --> 01:40:28.399
+Mom, Zod said this Codex...
+
+1019
+01:40:28.656 --> 01:40:30.932
+...he's looking for can
+bring my people back.
+
+1020
+01:40:31.259 --> 01:40:32.932
+Isn't that a good thing?
+
+1021
+01:40:37.164 --> 01:40:39.667
+I don't think they're interested
+in sharing this world.
+
+1022
+01:40:40.268 --> 01:40:41.508
+Clark.
+
+1023
+01:40:42.236 --> 01:40:43.112
+Clark.
+
+1024
+01:40:45.006 --> 01:40:46.883
+I know how to stop them.
+
+1025
+01:40:48.943 --> 01:40:50.388
+What happened down there?
+
+1026
+01:40:50.611 --> 01:40:53.455
+He exposed a temporary weakness.
+
+1027
+01:40:54.348 --> 01:40:56.191
+It is of little consequence...
+
+1028
+01:40:57.552 --> 01:41:00.465
+...because I have located the Codex.
+
+1029
+01:41:01.255 --> 01:41:03.531
+It was never in the capsule.
+
+1030
+01:41:04.125 --> 01:41:05.798
+<i>Jor-el took the Codex---</i>
+
+1031
+01:41:06.060 --> 01:41:08.540
+...the DNA of a billion people,
+then he bonded it...
+
+1032
+01:41:08.763 --> 01:41:10.572
+...within his son's individual...
+
+1033
+01:41:10.798 --> 01:41:11.742
+cells.
+
+1034
+01:41:11.966 --> 01:41:13.570
+All of Krypton's heirs...
+
+1035
+01:41:13.801 --> 01:41:17.248
+...living hidden in one refugee's body.
+
+1036
+01:41:21.309 --> 01:41:23.289
+Does Kal-EI need to be alive...
+
+1037
+01:41:23.544 --> 01:41:26.718
+...for us to extract the Codex from his cells?
+
+1038
+01:41:28.082 --> 01:41:29.254
+No.
+
+1039
+01:41:35.156 --> 01:41:37.432
+Release the world engine.
+
+1040
+01:42:09.657 --> 01:42:10.601
+“Mat just happened?
+
+1041
+01:42:10.758 --> 01:42:11.930
+The ship just split in mo.
+
+1042
+01:42:12.159 --> 01:42:15.265
+Track one is heading east,
+track two to the southern hemisphere.
+
+1043
+01:42:15.496 --> 01:42:17.942
+- How fast is that bogey moving?
+- Approaching...
+
+1044
+01:42:18.165 --> 01:42:19.610
+...Mach 24 and accelerating.
+
+1045
+01:42:19.834 --> 01:42:22.508
+It's gonna impact
+somewhere in the Indian Ocean.
+
+1046
+01:42:41.222 --> 01:42:42.860
+The rest of the ship is descending.
+
+1047
+01:42:43.858 --> 01:42:44.996
+Put it on the board now.
+
+1048
+01:42:45.226 --> 01:42:46.296
+Yes, sir.
+
+1049
+01:42:47.328 --> 01:42:48.500
+Oh, my God.
+
+1050
+01:43:29.003 --> 01:43:31.779
+Bring the phantom drive online.
+
+1051
+01:43:53.394 --> 01:43:55.237
+We are now slave to the world engine.
+
+1052
+01:43:56.964 --> 01:43:58.375
+Initiate.
+
+1053
+01:44:32.433 --> 01:44:35.846
+- What have they hit us with?
+- Looks like some kind of gravity...
+
+1054
+01:44:36.103 --> 01:44:38.640
+...weapon.
+It's working in tandem with their ship.
+
+1055
+01:44:40.074 --> 01:44:43.146
+Somehow they're increasing
+the Earth's mass...
+
+1056
+01:44:43.410 --> 01:44:45.515
+...clouding the atmosphere
+with particulates.
+
+1057
+01:44:47.248 --> 01:44:48.852
+Oh, my God.
+
+1058
+01:44:50.184 --> 01:44:51.185
+They're terraforming.
+
+1059
+01:44:51.952 --> 01:44:52.760
+What's that?
+
+1060
+01:44:53.587 --> 01:44:54.691
+Planetary engineering...
+
+1061
+01:44:54.955 --> 01:44:58.164
+...modifying the Earth's atmosphere
+and topography.
+
+1062
+01:44:58.425 --> 01:44:59.665
+Turning Earth into Krypton.
+
+1063
+01:45:00.361 --> 01:45:03.501
+- But what happens to us?
+- Based on these readings...
+
+1064
+01:45:03.764 --> 01:45:06.768
+...there won't be an "us."
+General Swanwick, sir.
+
+1065
+01:45:07.168 --> 01:45:08.545
+I'm on with the control tower.
+
+1066
+01:45:08.803 --> 01:45:11.044
+Colonel Hardy's on his way
+and he's got Superman in tow.
+
+1067
+01:45:11.772 --> 01:45:12.842
+Superman?
+
+1068
+01:45:13.374 --> 01:45:14.546
+The alien, sir.
+
+1069
+01:45:14.809 --> 01:45:17.187
+That's what they're calling him.
+Superman.
+
+1070
+01:45:22.683 --> 01:45:23.889
+We have a plan, general.
+
+1071
+01:45:24.151 --> 01:45:25.630
+Is that what I think it is?
+
+1072
+01:45:26.787 --> 01:45:28.562
+It's the ship he arrived in.
+
+1073
+01:45:30.224 --> 01:45:32.864
+This ship is powered by something
+called a phantom drive.
+
+1074
+01:45:33.127 --> 01:45:34.572
+It bends space.
+
+1075
+01:45:34.829 --> 01:45:38.800
+Zod's ship uses the same technology,
+and if we can make the two drives collide--
+
+1076
+01:45:39.033 --> 01:45:40.876
+A singularity can be created.
+
+1077
+01:45:41.135 --> 01:45:42.170
+- Like a black hole.
+- Yes.
+
+1078
+01:45:42.703 --> 01:45:44.205
+So if we open up this doorway...
+
+1079
+01:45:44.471 --> 01:45:46.075
+...they should be pulled back in.
+
+1080
+01:45:46.340 --> 01:45:48.843
+So you want us to bomb them with that?
+
+1081
+01:45:49.076 --> 01:45:51.056
+General, that craft maxes out...
+
+1082
+01:45:51.312 --> 01:45:54.691
+...17,000 pounds,
+we can drop it from a C-17.
+
+1083
+01:45:54.915 --> 01:45:56.053
+It's a viable plan.
+
+1084
+01:45:56.317 --> 01:45:58.422
+If I don't stop that machine
+over the Indian Ocean...
+
+1085
+01:45:58.686 --> 01:46:00.393
+...the gravity field will continue...
+
+1086
+01:46:00.654 --> 01:46:01.997
+...to expand.
+
+1087
+01:46:07.761 --> 01:46:10.537
+If that thing is making Earth
+more like Krypton...
+
+1088
+01:46:10.898 --> 01:46:12.434
+...won't you be weaker around it?
+
+1089
+01:46:14.235 --> 01:46:15.543
+Maybe.
+
+1090
+01:46:16.403 --> 01:46:18.883
+I'm not about to let that
+stop me from trying.
+
+1091
+01:46:19.840 --> 01:46:22.047
+You might want to step back a little bit.
+
+1092
+01:46:24.111 --> 01:46:25.249
+Maybe a little bit more.
+
+1093
+01:46:57.711 --> 01:46:58.314
+Faora.
+
+1094
+01:46:59.313 --> 01:47:00.417
+Take command.
+
+1095
+01:47:00.648 --> 01:47:03.788
+- Yes, sir.
+- I need to secure the genesis chamber...
+
+1096
+01:47:04.218 --> 01:47:06.960
+...and pay my respects to an old friend.
+
+1097
+01:47:14.728 --> 01:47:16.833
+Guardian en route to Metropolis...
+
+1098
+01:47:17.631 --> 01:47:18.837
+...package in tow.
+
+1099
+01:47:24.104 --> 01:47:27.017
+Be advised,
+F-35s inbound to rendezvous point.
+
+1100
+01:47:27.274 --> 01:47:29.447
+You should have visual contact now.
+
+1101
+01:48:14.455 --> 01:48:18.130
+Command key accepted.
+Genesis chamber coming online, sir.
+
+1102
+01:48:18.525 --> 01:48:19.469
+Stop this, Zod...
+
+1103
+01:48:19.693 --> 01:48:21.832
+...while there's still time.
+
+1104
+01:48:23.063 --> 01:48:26.374
+Haven't given up lecturing me,
+have you, even in death?
+
+1105
+01:48:26.734 --> 01:48:28.736
+I will not let you use the Codex like this.
+
+1106
+01:48:29.003 --> 01:48:30.710
+You don't have the power to stop me.
+
+1107
+01:48:30.971 --> 01:48:34.009
+The command key I have entered
+is revoking your authority.
+
+1108
+01:48:34.241 --> 01:48:37.154
+This ship is now under my control.
+
+1109
+01:49:08.675 --> 01:49:10.245
+Norlhcom, Lightning 1, request...
+
+1110
+01:49:10.511 --> 01:49:12.923
+- ...permission to unleash the hounds.
+- Lightning 1...
+
+1111
+01:49:13.180 --> 01:49:16.627
+...you are clear to engage. Send battle
+damage assessment when able. Out.
+
+1112
+01:49:30.197 --> 01:49:32.575
+Avionics are going haywire.
+The gravity field...
+
+1113
+01:49:32.800 --> 01:49:35.144
+...is pulling our missiles down.
+We gotta get closer.
+
+1114
+01:49:40.240 --> 01:49:41.275
+All right, everybody...
+
+1115
+01:49:41.542 --> 01:49:44.421
+...we're leaving.
+We're leaving the building now.
+
+1116
+01:50:07.568 --> 01:50:09.445
+I just lost my wingman.
+
+1117
+01:50:11.805 --> 01:50:12.943
+Mayday! Mayday! Mayday!
+
+1118
+01:50:24.518 --> 01:50:26.498
+Everybody, this way! Come on!
+
+1119
+01:50:26.753 --> 01:50:29.825
+Everybody, come on!
+Keep moving, keep moving.
+
+1120
+01:50:36.663 --> 01:50:37.698
+Jenny!
+
+1121
+01:50:41.668 --> 01:50:42.510
+Oh, my God.
+
+1122
+01:50:42.769 --> 01:50:43.770
+Perry!
+
+1123
+01:50:48.208 --> 01:50:50.154
+Go! There! Go!
+
+1124
+01:50:56.016 --> 01:50:57.518
+Our people can co-exist.
+
+1125
+01:50:58.152 --> 01:51:02.157
+So we can suffer through years of pain
+trying to adapt like your son has?
+
+1126
+01:51:02.990 --> 01:51:04.663
+- You're talking about genocide.
+- Yes.
+
+1127
+01:51:04.892 --> 01:51:07.498
+And I'm arguing its merits with a ghost.
+
+1128
+01:51:08.862 --> 01:51:10.671
+We're both ghosts, Zod.
+
+1129
+01:51:10.898 --> 01:51:14.402
+Can't you see that?
+The Krypton you're clinging onto is gone.
+
+1130
+01:51:14.668 --> 01:51:17.239
+Ship, have you managed to quarantine
+this invasive intelligence?
+
+1131
+01:51:17.504 --> 01:51:18.380
+- You'll fail.
+- I have.
+
+1132
+01:51:18.639 --> 01:51:20.050
+Then prepare to terminate it.
+
+1133
+01:51:20.307 --> 01:51:22.082
+- I'm tired of this debate.
+Silencing me...
+
+1134
+01:51:22.342 --> 01:51:23.753
+...won't change anything.
+
+1135
+01:51:26.013 --> 01:51:27.321
+My son...
+
+1136
+01:51:28.148 --> 01:51:29.491
+...is twice the man you were.
+
+1137
+01:51:32.486 --> 01:51:34.159
+And he will finish what we started.
+
+1138
+01:51:35.088 --> 01:51:36.328
+I can promise you that.
+
+1139
+01:51:41.528 --> 01:51:42.905
+Tell me...
+
+1140
+01:51:43.163 --> 01:51:46.736
+...you have Jor-El's memories,
+his conscience.
+
+1141
+01:51:47.434 --> 01:51:48.435
+Can you experience...
+
+1142
+01:51:48.702 --> 01:51:49.840
+...his pain?
+
+1143
+01:51:51.872 --> 01:51:55.445
+I will harvest the Codex
+from your son's corpse...
+
+1144
+01:51:55.909 --> 01:51:58.219
+...and I will rebuild Krypton...
+
+1145
+01:51:58.445 --> 01:52:00.948
+..atop his bones.
+
+1146
+01:52:29.276 --> 01:52:30.584
+Argh!
+
+1147
+01:52:58.639 --> 01:52:59.344
+Jenny.
+
+1148
+01:52:59.606 --> 01:53:02.348
+- Jenny. Jenny, where are you?
+- I'm here!
+
+1149
+01:53:02.609 --> 01:53:03.644
+- I'm here. Here.
+- Jenny.
+
+1150
+01:53:03.910 --> 01:53:05.412
+Hold on, hold on.
+
+1151
+01:53:05.646 --> 01:53:06.624
+I'm stuck.
+
+1152
+01:53:06.847 --> 01:53:08.520
+- I can't get free. I'm stuck.
+- Okay.
+
+1153
+01:53:08.782 --> 01:53:11.319
+We'll get you out of there, all right?
+Just sit tight.
+
+1154
+01:53:11.585 --> 01:53:12.154
+No, no, no!
+
+1155
+01:53:12.419 --> 01:53:14.126
+- Don't leave me.
+- We're not gonna leave you.
+
+1156
+01:53:14.354 --> 01:53:15.526
+- Okay.
+- Lombard!
+
+1157
+01:53:15.789 --> 01:53:19.134
+- Get your ass over here and help me.
+- Damn it.
+
+1158
+01:53:21.128 --> 01:53:23.108
+- We just gotta move this.
+- Here.
+
+1159
+01:53:23.330 --> 01:53:25.367
+Slide that in. You push, I'll pull, okay?
+
+1160
+01:53:25.632 --> 01:53:26.667
+Go.
+
+1161
+01:53:30.871 --> 01:53:32.179
+- Push!
+- Oh, my God.
+
+1162
+01:53:32.439 --> 01:53:34.043
+It's getting closer! Come on, push!
+
+1163
+01:53:36.109 --> 01:53:38.316
+Northcom, this is Guardian.
+Are we cleared?
+
+1164
+01:53:38.845 --> 01:53:39.846
+Negative, Guardian.
+
+1165
+01:54:04.571 --> 01:54:07.017
+Come on! Push!
+
+1166
+01:54:07.207 --> 01:54:08.208
+Ahh!
+
+1167
+01:54:33.200 --> 01:54:35.180
+Argh!
+
+1168
+01:54:59.025 --> 01:55:00.368
+He did it.
+
+1169
+01:55:02.562 --> 01:55:03.802
+Northcom, this is Guardian.
+
+1170
+01:55:04.064 --> 01:55:06.305
+We're passing through phase line red.
+Good to go.
+
+1171
+01:55:06.566 --> 01:55:07.476
+Godspeed, Guardian.
+
+1172
+01:55:07.734 --> 01:55:10.146
+Arm the package. You are cleared hot.
+
+1173
+01:55:10.404 --> 01:55:12.475
+We're lining up for the final run.
+
+1174
+01:55:13.273 --> 01:55:15.275
+It's up to you and Hamilton now.
+
+1175
+01:55:55.449 --> 01:55:56.189
+You gotta be kidding me.
+
+1176
+01:55:56.450 --> 01:55:57.861
+Loadmaster, is the package...
+
+1177
+01:55:58.118 --> 01:55:59.119
+...ready to drop?
+
+1178
+01:55:59.352 --> 01:56:00.626
+Negative, Guardian.
+
+1179
+01:56:00.854 --> 01:56:02.424
+There's something wrong.
+It's not supposed to do this.
+
+1180
+01:56:02.656 --> 01:56:04.431
+What's it supposed to do?
+
+1181
+01:56:04.658 --> 01:56:07.696
+- It's supposed to go in all the way.
+- Let me take a look.
+
+1182
+01:56:07.961 --> 01:56:09.531
+'Se-pilot's aircraft.
+
+1183
+01:56:10.263 --> 01:56:11.765
+Sea-pilot's aircraft.
+
+1184
+01:56:18.505 --> 01:56:21.179
+We are lined up for the drop.
+What's the hold up?
+
+1185
+01:56:21.441 --> 01:56:22.442
+We've had a setback.
+
+1186
+01:56:38.191 --> 01:56:39.693
+Target that aircraft.
+
+1187
+01:56:43.563 --> 01:56:45.008
+Target locked.
+
+1188
+01:56:54.808 --> 01:56:55.684
+Stop!
+
+1189
+01:56:55.909 --> 01:56:58.014
+If you destroy this ship...
+
+1190
+01:56:58.245 --> 01:57:00.919
+...you destroy Krypton!
+
+1191
+01:57:03.717 --> 01:57:05.890
+Krypton had its chance.
+
+1192
+01:57:07.420 --> 01:57:09.195
+Argh!
+
+1193
+01:57:59.873 --> 01:58:01.750
+Miss Lane! It's not safe for you...
+
+1194
+01:58:01.975 --> 01:58:02.885
+...over there!
+
+1195
+01:58:03.109 --> 01:58:03.712
+Miss Lane!
+
+1196
+01:58:05.312 --> 01:58:06.552
+Ah!
+
+1197
+01:58:33.607 --> 01:58:35.348
+Move now! Go!
+
+1198
+01:58:56.196 --> 01:58:57.197
+A good death...
+
+1199
+01:58:57.464 --> 01:58:59.034
+...is its own reward.
+
+1200
+01:59:06.640 --> 01:59:08.017
+Ah!
+
+1201
+01:59:29.562 --> 01:59:30.632
+Ah!
+
+1202
+01:59:47.414 --> 01:59:48.825
+Argh!
+
+1203
+02:00:01.494 --> 02:00:02.939
+Are they gone?
+
+1204
+02:00:04.097 --> 02:00:05.508
+I think so.
+
+1205
+02:00:07.400 --> 02:00:08.743
+He saved us.
+
+1206
+02:00:34.227 --> 02:00:37.436
+You know, they say it's all downhill
+after the first kiss.
+
+1207
+02:00:40.900 --> 02:00:43.938
+I'm pretty sure that only counts
+when you're kissing a human.
+
+1208
+02:01:13.299 --> 02:01:14.778
+Look at this.
+
+1209
+02:01:17.070 --> 02:01:18.981
+We could have built a new Krypton...
+
+1210
+02:01:19.239 --> 02:01:20.980
+...in this squalor.
+
+1211
+02:01:21.241 --> 02:01:24.347
+But you chose the humans over us.
+
+1212
+02:01:25.779 --> 02:01:27.315
+I exist...
+
+1213
+02:01:27.580 --> 02:01:29.992
+...only to protect Krypton.
+
+1214
+02:01:31.751 --> 02:01:35.756
+That is the sole purpose
+for which I was born.
+
+1215
+02:01:36.990 --> 02:01:39.129
+And every action I take...
+
+1216
+02:01:39.359 --> 02:01:41.361
+...no matter how violent...
+
+1217
+02:01:41.628 --> 02:01:43.335
+...or how cruel...
+
+1218
+02:01:44.531 --> 02:01:46.943
+...is for the greater good...
+
+1219
+02:01:47.167 --> 02:01:49.113
+...of my people.
+
+1220
+02:01:53.439 --> 02:01:54.850
+And now...
+
+1221
+02:01:55.108 --> 02:01:57.384
+...I have no people.
+
+1222
+02:02:00.814 --> 02:02:02.384
+My soul...
+
+1223
+02:02:04.484 --> 02:02:08.022
+...that is what you have taken...
+
+1224
+02:02:08.288 --> 02:02:09.892
+...from me.
+
+1225
+02:02:16.796 --> 02:02:19.299
+I'm going to make them suffer, Kal.
+
+1226
+02:02:19.532 --> 02:02:22.979
+These humans you've adopted,
+I will take them all from you...
+
+1227
+02:02:23.203 --> 02:02:26.184
+...one by one.
+- You're a monster, Zod...
+
+1228
+02:02:28.808 --> 02:02:30.014
+...and I'm gonna stop you.
+
+1229
+02:02:42.488 --> 02:02:43.694
+Argh!
+
+1230
+02:02:51.998 --> 02:02:52.669
+Argh!
+
+1231
+02:04:11.611 --> 02:04:12.316
+There's only...
+
+1232
+02:04:12.578 --> 02:04:13.921
+...one way this ends, Kal.
+
+1233
+02:04:14.147 --> 02:04:15.990
+Either you die...
+
+1234
+02:04:16.249 --> 02:04:17.023
+...or I do.
+
+1235
+02:04:38.204 --> 02:04:39.114
+Unh!
+
+1236
+02:04:48.681 --> 02:04:50.820
+I was bred to be a warrior, Kal.
+
+1237
+02:04:51.684 --> 02:04:53.322
+Trained my entire life...
+
+1238
+02:04:53.553 --> 02:04:55.396
+...to master my senses.
+
+1239
+02:04:55.888 --> 02:04:59.495
+Where did you train? On a farm?
+
+1240
+02:06:51.270 --> 02:06:52.908
+Argh!
+
+1241
+02:07:08.421 --> 02:07:09.866
+If you love...
+
+1242
+02:07:10.123 --> 02:07:12.467
+...these people so much...
+
+1243
+02:07:13.192 --> 02:07:15.468
+...you can mourn for them.
+
+1244
+02:07:19.932 --> 02:07:21.002
+Don't do this!
+
+1245
+02:07:24.203 --> 02:07:25.011
+Stop!
+
+1246
+02:07:31.377 --> 02:07:32.355
+Stop!
+
+1247
+02:07:34.714 --> 02:07:35.852
+Never.
+
+1248
+02:08:05.845 --> 02:08:07.347
+Ahh!
+
+1249
+02:09:10.543 --> 02:09:11.920
+Are you effing stupid?
+
+1250
+02:09:12.144 --> 02:09:13.885
+It's one of your surveillance drones.
+
+1251
+02:09:14.113 --> 02:09:16.616
+That's a $12,000,000 piece of hardware.
+
+1252
+02:09:16.782 --> 02:09:17.817
+It was.
+
+1253
+02:09:18.618 --> 02:09:21.155
+I know you're trying to find out
+where I hang my cape.
+
+1254
+02:09:21.754 --> 02:09:23.233
+- You won't.
+- Then I'll ask...
+
+1255
+02:09:23.456 --> 02:09:24.764
+...the obvious question:
+
+1256
+02:09:25.224 --> 02:09:28.228
+How do we know you won't one day
+act against America's interests?
+
+1257
+02:09:28.928 --> 02:09:30.771
+I grew up in Kansas, general.
+
+1258
+02:09:31.230 --> 02:09:33.403
+I'm about as American as it gets.
+
+1259
+02:09:33.666 --> 02:09:34.576
+Look...
+
+1260
+02:09:34.800 --> 02:09:36.279
+...I'm hereto help...
+
+1261
+02:09:36.502 --> 02:09:38.743
+...but it has to be on my own terms.
+
+1262
+02:09:38.971 --> 02:09:40.814
+You have to convince Washington of that.
+
+1263
+02:09:41.073 --> 02:09:45.078
+Even if I were willing to try,
+what makes you think they'd listen?
+
+1264
+02:09:46.145 --> 02:09:47.749
+I don't know, general.
+
+1265
+02:09:49.148 --> 02:09:50.855
+Guess I'll just have to trust you.
+
+1266
+02:10:00.426 --> 02:10:01.803
+What are you smiling about?
+
+1267
+02:10:02.628 --> 02:10:03.971
+Nothing, sir.
+
+1268
+02:10:07.133 --> 02:10:09.113
+I just think he's kind of hot.
+
+1269
+02:10:11.270 --> 02:10:13.375
+- Get in the car, captain.
+- Mm-hm. Yes, sir.
+
+1270
+02:10:23.349 --> 02:10:26.558
+He always believed
+you were meant for greater things.
+
+1271
+02:10:26.819 --> 02:10:28.321
+And that when the day came...
+
+1272
+02:10:28.554 --> 02:10:31.364
+...your shoulders would be able
+to bear the weight.
+
+1273
+02:10:31.624 --> 02:10:35.470
+Yeah, I just wish he could have
+been here to see it finally happen.
+
+1274
+02:10:35.895 --> 02:10:37.875
+He saw it, Clark, believe me.
+
+1275
+02:11:25.378 --> 02:11:28.222
+What are you going to do
+when you're not saving the world?
+
+1276
+02:11:28.447 --> 02:11:32.190
+- Have you given any thought to that?
+- I have, actually. Heh, heh.
+
+1277
+02:11:33.786 --> 02:11:37.791
+I gotta find a job
+where I can keep my ear to the ground.
+
+1278
+02:11:43.028 --> 02:11:45.099
+Where people won't look twice...
+
+1279
+02:11:45.364 --> 02:11:49.141
+...when I want to go somewhere dangerous
+and start asking questions.
+
+1280
+02:12:03.249 --> 02:12:06.287
+Come on, Lois.
+When are you gonna throw me a bone?
+
+1281
+02:12:07.553 --> 02:12:09.226
+Courtside seats to the game tonight.
+
+1282
+02:12:09.655 --> 02:12:11.225
+- What do you say?
+- I say...
+
+1283
+02:12:11.457 --> 02:12:13.994
+...you should go back
+to trolling the intern pool.
+
+1284
+02:12:14.260 --> 02:12:17.639
+You'll probably have more luck. Sorry.
+
+1285
+02:12:19.432 --> 02:12:20.103
+Courtside?
+
+1286
+02:12:20.332 --> 02:12:22.073
+- Don't. Ha, ha, ha.
+- No.
+
+1287
+02:12:22.301 --> 02:12:25.111
+Lombard, Lane,
+I want you to meet our new stringer.
+
+1288
+02:12:25.337 --> 02:12:28.580
+I want you to show him the ropes.
+This is Clark Kent.
+
+1289
+02:12:28.808 --> 02:12:30.116
+Good luck, kid.
+
+1290
+02:12:31.644 --> 02:12:32.918
+Hey. Steve.
+
+1291
+02:12:33.145 --> 02:12:34.419
+- Nice to meet you.
+- You too.
+
+1292
+02:12:34.647 --> 02:12:35.489
+Hi.
+
+1293
+02:12:36.415 --> 02:12:37.758
+Lois Lane.
+
+1294
+02:12:38.584 --> 02:12:40.120
+Welcome to the Planet.
+
+1295
+02:12:43.856 --> 02:12:45.836
+Glad to be here, Lois.
+
+1296
+02:12:50.000 --> 02:12:56.000
+Checks & Fixes (OCR, Sync, Spelling & Common Errors)
+by SNUIF
+
+1297
+02:12:57.000 --> 02:13:00.000
+Source: PublicHD
+
+1298
+02:13:01.305 --> 02:13:07.267
+Support us and become VIP member
+to remove all ads from OpenSubtitles.org

--- a/test/examples/Wonder Woman 2017 (BluRay 1080p x265 10bit 7.1)_track3_eng.vtt
+++ b/test/examples/Wonder Woman 2017 (BluRay 1080p x265 10bit 7.1)_track3_eng.vtt
@@ -1,0 +1,6747 @@
+﻿WEBVTT
+
+1
+00:00:48.842 --> 00:00:51.428
+<i>I used to want to save the world.</i>
+
+2
+00:00:53.013 --> 00:00:55.224
+<i>This beautiful place.</i>
+
+3
+00:00:57.100 --> 00:00:59.102
+<i>But I knew so little then.</i>
+
+4
+00:01:01.355 --> 00:01:03.774
+<i>It is a land of magic and wonder.</i>
+
+5
+00:01:04.691 --> 00:01:07.319
+<i>Worth cherishing in every way.</i>
+
+6
+00:01:09.613 --> 00:01:11.448
+<i>But the closer you get,</i>
+
+7
+00:01:12.699 --> 00:01:16.286
+<i>the more you see the great darkness
+simmering within.</i>
+
+8
+00:01:20.707 --> 00:01:23.252
+<i>And mankind?</i>
+
+9
+00:01:24.294 --> 00:01:26.922
+<i>Mankind is another story altogether.</i>
+
+10
+00:01:29.258 --> 00:01:34.179
+<i>What one does when faced with the truth
+is more difficult than you think.</i>
+
+11
+00:01:44.439 --> 00:01:46.191
+<i>I learned this the hard way.</i>
+
+12
+00:01:47.484 --> 00:01:49.319
+<i>A long, long time ago.</i>
+
+13
+00:01:52.197 --> 00:01:53.198
+<i>And now,</i>
+
+14
+00:01:56.034 --> 00:01:57.703
+<i>I will never be the same.</i>
+
+15
+00:02:05.377 --> 00:02:06.378
+<i>Merci.</i>
+
+16
+00:02:53.300 --> 00:02:54.593
+Hello, Diana.
+
+17
+00:02:54.760 --> 00:02:56.511
+- Hello, Diana.
+- Hello.
+
+18
+00:02:57.179 --> 00:02:58.472
+<i>Diana!</i>
+
+19
+00:02:59.514 --> 00:03:00.974
+Diana!
+
+20
+00:03:01.558 --> 00:03:02.559
+<i>Come back!</i>
+
+21
+00:03:42.307 --> 00:03:43.809
+- It looks very good.
+- Very good.
+
+22
+00:03:43.975 --> 00:03:44.976
+How is she doing?
+
+23
+00:03:45.143 --> 00:03:46.144
+She's good.
+
+24
+00:03:46.311 --> 00:03:47.646
+- Keep working with her.
+- I will.
+
+25
+00:03:48.855 --> 00:03:49.856
+Naomi.
+
+26
+00:04:12.337 --> 00:04:13.380
+Diana!
+
+27
+00:04:15.006 --> 00:04:16.341
+Diana, I see you.
+
+28
+00:04:22.681 --> 00:04:24.724
+Where are you going?
+Slow down!
+
+29
+00:04:34.860 --> 00:04:36.862
+Hello, Mother.
+
+30
+00:04:37.446 --> 00:04:38.864
+How are you today?
+
+31
+00:04:40.365 --> 00:04:42.909
+<i>Let's get you back to school
+before another tutor quits.</i>
+
+32
+00:04:43.076 --> 00:04:46.621
+But don't you think
+it's time to start my training?
+
+33
+00:04:47.205 --> 00:04:49.040
+Antiope thinks I'm ready.
+
+34
+00:04:50.041 --> 00:04:51.042
+Does she?
+
+35
+00:04:51.960 --> 00:04:54.379
+I could begin showing her some things.
+
+36
+00:04:56.214 --> 00:04:58.383
+She should at least
+be able to defend herself.
+
+37
+00:04:58.550 --> 00:04:59.593
+From whom?
+
+38
+00:04:59.759 --> 00:05:01.720
+In the event of an invasion.
+
+39
+00:05:01.887 --> 00:05:05.223
+<i>Isn't that why I have
+the greatest warrior in our history</i>
+
+40
+00:05:05.390 --> 00:05:07.726
+leading an entire army, General?
+
+41
+00:05:08.894 --> 00:05:11.813
+I pray a day will never come
+where she has to fight.
+
+42
+00:05:11.980 --> 00:05:15.066
+But you know,
+a scorpion must sting,
+
+43
+00:05:15.233 --> 00:05:17.819
+<i>- a wolf must hunt--</i>
+- She is a child.
+
+44
+00:05:17.986 --> 00:05:19.946
+<i>The only child on the island.
+Please let her be so.</i>
+
+45
+00:05:20.113 --> 00:05:21.114
+<i>But, Mother...</i>
+
+46
+00:05:21.281 --> 00:05:22.824
+There will be no training.
+
+47
+00:05:30.749 --> 00:05:32.209
+<i>What if I promised to be careful?</i>
+
+48
+00:05:33.335 --> 00:05:34.920
+It's time to sleep.
+
+49
+00:05:36.713 --> 00:05:39.007
+What if I didn't use a sword?
+
+50
+00:05:39.591 --> 00:05:41.843
+Fighting does not make you a hero.
+
+51
+00:05:42.427 --> 00:05:44.763
+Just a shield then. No sharp edges.
+
+52
+00:05:44.930 --> 00:05:49.100
+Diana, you are the most
+precious thing in the world to me.
+
+53
+00:05:50.185 --> 00:05:53.980
+I wished for you so much so,
+I sculpted you from clay myself
+
+54
+00:05:54.147 --> 00:05:56.691
+and begged Zeus to give you life.
+
+55
+00:05:56.858 --> 00:05:58.652
+You've told me this story.
+
+56
+00:05:59.236 --> 00:06:02.656
+Which is why tonight
+I will tell you a new one.
+
+57
+00:06:03.281 --> 00:06:06.451
+A story of our people,
+and my days of battle.
+
+58
+00:06:06.618 --> 00:06:07.619
+Yes!
+
+59
+00:06:07.786 --> 00:06:11.289
+So you will finally understand
+why war is nothing to hope for.
+
+60
+00:06:17.629 --> 00:06:20.340
+Long ago, when time was new
+
+61
+00:06:21.007 --> 00:06:23.969
+and all of history was still a dream,
+
+62
+00:06:24.135 --> 00:06:26.471
+<i>the Gods ruled the Earth,</i>
+
+63
+00:06:26.638 --> 00:06:29.307
+<i>Zeus king among them.</i>
+
+64
+00:06:31.851 --> 00:06:35.021
+<i>Zeus created beings
+over which the Gods would rule.</i>
+
+65
+00:06:35.564 --> 00:06:38.066
+<i>Beings born in his image,</i>
+
+66
+00:06:38.233 --> 00:06:41.903
+<i>fair and good,
+strong and passionate.</i>
+
+67
+00:06:42.821 --> 00:06:46.741
+He called his creation "man."
+And mankind was good.
+
+68
+00:06:47.742 --> 00:06:50.912
+But Zeus's son grew envious of mankind
+
+69
+00:06:51.079 --> 00:06:54.332
+and sought to corrupt
+his father's creation.
+
+70
+00:06:55.333 --> 00:06:58.837
+<i>This was Ares, the God of War.</i>
+
+71
+00:07:01.006 --> 00:07:05.218
+Ares poisoned men's hearts
+with jealousy and suspicion.
+
+72
+00:07:05.385 --> 00:07:07.512
+<i>He turned them against one another</i>
+
+73
+00:07:07.679 --> 00:07:10.682
+<i>and war ravaged the Earth.</i>
+
+74
+00:07:11.683 --> 00:07:15.729
+<i>So, the Gods created us, the Amazons,</i>
+
+75
+00:07:15.895 --> 00:07:18.523
+<i>to influence men's hearts with love</i>
+
+76
+00:07:18.690 --> 00:07:21.192
+<i>and restore peace to the Earth.</i>
+
+77
+00:07:24.237 --> 00:07:27.365
+<i>And for a brief time, there was peace.</i>
+
+78
+00:07:33.246 --> 00:07:34.748
+<i>But it did not last.</i>
+
+79
+00:07:41.421 --> 00:07:45.091
+<i>Your mother, the Amazon Queen,
+led a revolt</i>
+
+80
+00:07:45.258 --> 00:07:48.219
+<i>that freed us all from enslavement.</i>
+
+81
+00:07:55.310 --> 00:07:58.480
+<i>When Zeus led the Gods to our defense,</i>
+
+82
+00:07:58.647 --> 00:08:01.900
+<i>Ares killed them one by one,</i>
+
+83
+00:08:02.067 --> 00:08:05.236
+<i>until only Zeus himself remained.</i>
+
+84
+00:08:06.571 --> 00:08:10.950
+<i>Zeus used the last of his power
+to stop Ares,</i>
+
+85
+00:08:11.785 --> 00:08:16.581
+<i>striking such a blow,
+the God of War was forced to retreat.</i>
+
+86
+00:08:17.791 --> 00:08:18.917
+<i>But Zeus knew</i>
+
+87
+00:08:19.084 --> 00:08:23.254
+<i>that one day, Ares might return
+to finish his mission.</i>
+
+88
+00:08:23.838 --> 00:08:26.299
+<i>An endless war,</i>
+
+89
+00:08:26.466 --> 00:08:29.469
+<i>where mankind would finally
+destroy themselves,</i>
+
+90
+00:08:29.636 --> 00:08:32.430
+<i>and us with them.</i>
+
+91
+00:08:32.597 --> 00:08:35.016
+<i>So Zeus left us a weapon,</i>
+
+92
+00:08:35.183 --> 00:08:38.269
+<i>one powerful enough to kill a God.</i>
+
+93
+00:08:39.437 --> 00:08:43.441
+<i>With his dying breath,
+Zeus created this island</i>
+
+94
+00:08:43.608 --> 00:08:45.860
+<i>to hide us from the outside world,</i>
+
+95
+00:08:46.027 --> 00:08:48.363
+<i>somewhere Ares could not find us.</i>
+
+96
+00:08:52.826 --> 00:08:55.120
+<i>And all has been quiet ever since.</i>
+
+97
+00:09:02.836 --> 00:09:07.006
+We give thanks to the Gods
+for giving us this paradise.
+
+98
+00:09:08.967 --> 00:09:10.468
+And the Godkiller?
+
+99
+00:09:15.181 --> 00:09:16.182
+The Godkiller?
+
+100
+00:09:16.349 --> 00:09:18.977
+The weapon that's strong enough
+to kill a god.
+
+101
+00:09:19.978 --> 00:09:21.312
+<i>Can I see it?</i>
+
+102
+00:09:31.364 --> 00:09:33.199
+The Gods gave us many gifts.
+
+103
+00:09:33.867 --> 00:09:35.660
+One day, you'll know them all.
+
+104
+00:09:36.161 --> 00:09:39.080
+This great tower is where we keep them.
+
+105
+00:09:51.509 --> 00:09:52.677
+The Godkiller.
+
+106
+00:09:56.514 --> 00:09:57.974
+<i>It's beautiful.</i>
+
+107
+00:09:59.559 --> 00:10:00.935
+Who would wield it?
+
+108
+00:10:03.438 --> 00:10:06.024
+I pray it will never be called to arms.
+
+109
+00:10:06.733 --> 00:10:09.694
+But only the fiercest among us even could.
+
+110
+00:10:10.278 --> 00:10:12.071
+And that is not you, Diana.
+
+111
+00:10:12.864 --> 00:10:15.283
+You see, you're safe,
+
+112
+00:10:15.784 --> 00:10:18.787
+and there is nothing
+you should concern yourself with.
+
+113
+00:10:32.342 --> 00:10:33.968
+You keep doubting yourself, Diana.
+
+114
+00:10:34.135 --> 00:10:36.346
+- No, I don't.
+- Yes, you do.
+
+115
+00:10:37.055 --> 00:10:38.223
+No, I don't.
+
+116
+00:10:43.061 --> 00:10:44.312
+You are stronger than you believe.
+
+117
+00:10:44.479 --> 00:10:46.564
+<i>You have greater powers than you know.</i>
+
+118
+00:10:46.731 --> 00:10:48.650
+<i>- But if you don't try hard--
+- Diana!</i>
+
+119
+00:11:00.411 --> 00:11:01.412
+Are you hurt?
+
+120
+00:11:01.996 --> 00:11:03.164
+No, Mother, I'm fine,
+
+121
+00:11:03.373 --> 00:11:05.041
+- I was just--
+- Training.
+
+122
+00:11:06.000 --> 00:11:09.045
+It seems I'm not
+the revered queen I should be.
+
+123
+00:11:09.212 --> 00:11:11.422
+Disobeyed, betrayed by my own sister...
+
+124
+00:11:11.589 --> 00:11:13.800
+No, Mother.
+It was me, I asked her to--
+
+125
+00:11:13.967 --> 00:11:15.176
+Take her to the palace.
+
+126
+00:11:17.011 --> 00:11:18.012
+Off you go.
+
+127
+00:11:26.604 --> 00:11:28.731
+You left me no choice, Hippolyta.
+
+128
+00:11:30.400 --> 00:11:33.152
+You neglect your duty if she cannot fight.
+
+129
+00:11:33.319 --> 00:11:35.405
+You speak of a time that may never come.
+
+130
+00:11:36.990 --> 00:11:38.491
+He might never return.
+
+131
+00:11:39.576 --> 00:11:41.369
+He could have died from his wounds.
+
+132
+00:11:41.536 --> 00:11:44.455
+Ares is alive.
+
+133
+00:11:44.622 --> 00:11:47.959
+You feel it, as I do, in your bones.
+
+134
+00:11:48.585 --> 00:11:51.254
+It is only a matter of time
+before he returns.
+
+135
+00:11:55.174 --> 00:11:59.012
+The stronger she gets,
+the sooner he'll find her.
+
+136
+00:11:59.178 --> 00:12:01.931
+Hippolyta, I love her as you do.
+
+137
+00:12:03.474 --> 00:12:06.394
+But this is the only way
+to truly protect her.
+
+138
+00:12:17.447 --> 00:12:20.867
+You will train her harder than
+any Amazon before her.
+
+139
+00:12:21.618 --> 00:12:23.453
+<i>Five times harder,</i>
+
+140
+00:12:23.620 --> 00:12:25.663
+<i>ten times harder.</i>
+
+141
+00:12:25.830 --> 00:12:28.750
+<i>Until she is better than even you.</i>
+
+142
+00:12:29.334 --> 00:12:31.294
+<i>But she must never know the truth</i>
+
+143
+00:12:31.461 --> 00:12:33.212
+<i>about what she is</i>
+
+144
+00:12:33.379 --> 00:12:35.214
+<i>or how she came to be.</i>
+
+145
+00:13:29.852 --> 00:13:31.104
+Harder.
+
+146
+00:13:31.270 --> 00:13:34.065
+<i>You're stronger than this, Diana.</i>
+
+147
+00:13:34.273 --> 00:13:35.400
+Again.
+
+148
+00:13:52.542 --> 00:13:54.002
+Never let your guard down.
+
+149
+00:13:55.211 --> 00:13:56.963
+You expect the battle to be fair.
+
+150
+00:13:57.130 --> 00:13:58.548
+A battle will never be fair.
+
+151
+00:14:12.478 --> 00:14:13.479
+Antiope!
+
+152
+00:14:15.398 --> 00:14:16.399
+Lay still.
+
+153
+00:14:16.774 --> 00:14:17.775
+You are bleeding.
+
+154
+00:14:19.527 --> 00:14:21.779
+- I'm sorry...
+- Wait, Diana, wait.
+
+155
+00:14:28.077 --> 00:14:29.245
+What have I done?
+
+156
+00:14:31.080 --> 00:14:32.165
+I'm sorry.
+
+157
+00:17:03.774 --> 00:17:05.776
+<i>Where did this fog come from?</i>
+
+158
+00:17:09.655 --> 00:17:12.200
+There. Go forward!
+
+159
+00:17:29.342 --> 00:17:31.427
+<i>There he is! The pilot! I can see him.</i>
+
+160
+00:17:31.594 --> 00:17:32.803
+He's there!
+
+161
+00:18:03.668 --> 00:18:04.669
+Wow.
+
+162
+00:18:07.755 --> 00:18:09.090
+You're a man.
+
+163
+00:18:13.594 --> 00:18:16.347
+Yeah. I mean...
+
+164
+00:18:18.516 --> 00:18:20.017
+Do I not look like one?
+
+165
+00:18:24.605 --> 00:18:25.815
+Where are we?
+
+166
+00:18:26.357 --> 00:18:27.858
+Themyscira.
+
+167
+00:18:28.025 --> 00:18:29.277
+Therma-what?
+
+168
+00:18:29.777 --> 00:18:30.778
+Who are you?
+
+169
+00:18:39.161 --> 00:18:41.789
+I'm one of the good guys,
+and those are the bad guys.
+
+170
+00:18:41.956 --> 00:18:42.999
+What?
+
+171
+00:18:43.165 --> 00:18:44.875
+The Germans. Come on,
+we need to get out of here.
+
+172
+00:18:45.042 --> 00:18:47.169
+- The Germans?
+<i>- Diana!</i>
+
+173
+00:18:47.336 --> 00:18:49.547
+Step away from her, now!
+
+174
+00:18:51.799 --> 00:18:53.050
+<i>Ready your bows!</i>
+
+175
+00:18:56.554 --> 00:18:57.888
+They have guns, right?
+
+176
+00:18:58.055 --> 00:18:59.640
+Fire!
+
+177
+00:19:00.850 --> 00:19:02.393
+Fire!
+
+178
+00:19:03.519 --> 00:19:04.895
+Come on!
+
+179
+00:20:42.076 --> 00:20:43.077
+Stay there!
+
+180
+00:21:21.115 --> 00:21:22.199
+Shield!
+
+181
+00:21:43.387 --> 00:21:45.139
+No!
+
+182
+00:21:45.306 --> 00:21:46.307
+No!
+
+183
+00:21:52.188 --> 00:21:53.564
+No.
+
+184
+00:21:53.731 --> 00:21:57.693
+No, no. Antiope. Antiope.
+
+185
+00:21:57.860 --> 00:22:00.529
+Antiope, hey. Hey, hey.
+
+186
+00:22:02.323 --> 00:22:03.324
+Hey.
+
+187
+00:22:03.908 --> 00:22:04.909
+- Diana.
+- Be still.
+
+188
+00:22:06.744 --> 00:22:08.204
+The time has come.
+
+189
+00:22:09.413 --> 00:22:11.415
+You... You must...
+
+190
+00:22:11.582 --> 00:22:14.752
+What? What, Antiope?
+
+191
+00:22:18.881 --> 00:22:20.257
+Godkiller.
+
+192
+00:22:20.841 --> 00:22:22.885
+- Diana, go...
+- Go where?
+
+193
+00:22:23.677 --> 00:22:25.012
+- Go where?
+- Go...
+
+194
+00:22:25.179 --> 00:22:28.057
+No, please, no. No. No!
+
+195
+00:22:28.224 --> 00:22:30.184
+No, no, no.
+
+196
+00:22:30.976 --> 00:22:32.811
+- No!
+- Antiope!
+
+197
+00:22:34.396 --> 00:22:35.564
+No!
+
+198
+00:22:42.780 --> 00:22:44.114
+- You.
+- No.
+
+199
+00:22:45.533 --> 00:22:47.034
+No, Mother, no.
+
+200
+00:22:47.201 --> 00:22:48.953
+He fought at my side against the invaders.
+
+201
+00:22:49.119 --> 00:22:50.955
+What man fights against his own people?
+
+202
+00:22:51.121 --> 00:22:53.958
+- These aren't my people.
+- Then why do you wear their colors?
+
+203
+00:22:56.085 --> 00:22:57.086
+I can't tell you that.
+
+204
+00:22:57.253 --> 00:22:58.295
+You need to tell us now!
+
+205
+00:22:58.462 --> 00:22:59.505
+What is your name?
+
+206
+00:23:00.881 --> 00:23:02.258
+I can't tell you that either.
+
+207
+00:23:03.092 --> 00:23:05.886
+We should kill him now,
+and be done with it.
+
+208
+00:23:06.053 --> 00:23:07.054
+<i>If he dies,</i>
+
+209
+00:23:07.721 --> 00:23:12.393
+we know nothing about who they are,
+and why they came.
+
+210
+00:23:19.984 --> 00:23:21.735
+My, uh,
+
+211
+00:23:23.153 --> 00:23:27.658
+name is Captain Steve Trevor,
+pilot, American Expeditionary Forces.
+
+212
+00:23:27.825 --> 00:23:30.953
+Serial number 8141921.
+
+213
+00:23:31.161 --> 00:23:33.372
+That's all I'm at liberty to...
+
+214
+00:23:37.668 --> 00:23:39.503
+Assigned to British Intelligence.
+
+215
+00:23:41.297 --> 00:23:42.965
+What the hell is this thing?
+
+216
+00:23:43.132 --> 00:23:46.176
+The Lasso of Hestia compels you
+to reveal the truth.
+
+217
+00:23:46.719 --> 00:23:48.178
+But it's really hot.
+
+218
+00:23:48.345 --> 00:23:51.348
+It is pointless, and painful, to resist.
+
+219
+00:23:52.099 --> 00:23:53.309
+What is your mission?
+
+220
+00:23:53.475 --> 00:23:57.271
+Whoever you are,
+you are in more danger than you think.
+
+221
+00:23:57.438 --> 00:23:58.480
+What is your mission?
+
+222
+00:24:01.859 --> 00:24:02.860
+I am a...
+
+223
+00:24:07.531 --> 00:24:08.532
+I am a...
+
+224
+00:24:11.869 --> 00:24:13.203
+I am a spy.
+
+225
+00:24:16.540 --> 00:24:19.001
+I'm a spy. I'm a spy.
+
+226
+00:24:21.754 --> 00:24:23.047
+<i>British Intelligence got word</i>
+
+227
+00:24:23.213 --> 00:24:25.674
+<i>that the leader of the German Army,
+General Ludendorff,</i>
+
+228
+00:24:25.841 --> 00:24:29.720
+<i>would be visiting a secret military
+installation in the Ottoman Empire.</i>
+
+229
+00:24:29.887 --> 00:24:33.057
+<i>I posed as one of their pilots,
+and flew in with them.</i>
+
+230
+00:24:33.223 --> 00:24:36.727
+<i>According to our intel,
+the Germans had no troops left,</i>
+
+231
+00:24:36.894 --> 00:24:39.563
+<i>no money, no munitions of any kind.</i>
+
+232
+00:24:39.730 --> 00:24:41.065
+<i>But our intel was wrong.</i>
+
+233
+00:24:41.231 --> 00:24:43.942
+<i>The Germans had the Turks
+building bombs for them.</i>
+
+234
+00:24:44.109 --> 00:24:47.237
+<i>And not just bombs, new weapons.</i>
+
+235
+00:24:47.404 --> 00:24:48.989
+<i>Secret weapons.</i>
+
+236
+00:24:50.449 --> 00:24:55.204
+<i>Invented by Ludendorff's
+chief psychopath, Dr. Isabel Maru.</i>
+
+237
+00:24:56.580 --> 00:24:59.083
+<i>The boys in the trenches
+called her "Dr. Poison."</i>
+
+238
+00:25:00.584 --> 00:25:01.710
+<i>And for good reason.</i>
+
+239
+00:25:30.572 --> 00:25:34.076
+<i>From what I could tell, if Dr. Maru
+was able to complete her work,</i>
+
+240
+00:25:34.243 --> 00:25:37.287
+<i>millions more would die.
+The war would never end.</i>
+
+241
+00:25:37.955 --> 00:25:40.040
+<i>I was there to observe and report,
+nothing more,</i>
+
+242
+00:25:41.750 --> 00:25:43.585
+<i>but I had to do something.</i>
+
+243
+00:25:48.674 --> 00:25:49.967
+<i>I'm so close.</i>
+
+244
+00:25:50.134 --> 00:25:53.178
+<i>I know I can make the gas
+penetrate the mask.</i>
+
+245
+00:25:53.345 --> 00:25:55.556
+I just... I need more time.
+
+246
+00:25:55.723 --> 00:25:57.474
+Unfortunately, Doctor,
+we do not have more time.
+
+247
+00:25:57.641 --> 00:25:59.560
+This work, this...
+
+248
+00:26:04.898 --> 00:26:06.150
+Get that man!
+
+249
+00:26:06.316 --> 00:26:07.526
+<i>There!</i>
+
+250
+00:27:01.538 --> 00:27:04.958
+But if I can get these notes back
+to British Intelligence in time,
+
+251
+00:27:05.709 --> 00:27:08.295
+it could stop millions more from dying.
+
+252
+00:27:09.296 --> 00:27:11.215
+It could stop the war.
+
+253
+00:27:11.381 --> 00:27:13.509
+War? What war?
+
+254
+00:27:15.719 --> 00:27:17.137
+The war.
+
+255
+00:27:20.057 --> 00:27:22.559
+The war to end all wars.
+
+256
+00:27:23.894 --> 00:27:25.604
+<i>Four years,</i>
+
+257
+00:27:25.771 --> 00:27:28.023
+<i>27 countries,</i>
+
+258
+00:27:28.190 --> 00:27:30.150
+25 million dead,
+
+259
+00:27:30.734 --> 00:27:32.736
+<i>soldiers and civilians.</i>
+
+260
+00:27:32.903 --> 00:27:34.822
+Innocent people,
+
+261
+00:27:35.739 --> 00:27:37.991
+women and children slaughtered.
+
+262
+00:27:39.326 --> 00:27:42.830
+<i>Their homes and their villages
+looted and burned.</i>
+
+263
+00:27:46.917 --> 00:27:49.169
+Weapons far deadlier than you can
+
+264
+00:27:52.089 --> 00:27:53.590
+ever imagine.
+
+265
+00:27:57.928 --> 00:27:59.680
+It's like nothing I've ever seen.
+
+266
+00:28:01.098 --> 00:28:02.850
+<i>It's like the world's going to end.</i>
+
+267
+00:28:05.102 --> 00:28:06.353
+Should we let him go?
+
+268
+00:28:06.520 --> 00:28:09.106
+And risk him bringing
+more men to our shores?
+
+269
+00:28:09.273 --> 00:28:11.358
+We cannot hold him forever, my queen.
+
+270
+00:28:11.525 --> 00:28:13.610
+Mother. Excuse me,
+
+271
+00:28:13.777 --> 00:28:17.614
+but after everything the man said,
+this must be Ares.
+
+272
+00:28:17.781 --> 00:28:19.032
+What are you talking about, child?
+
+273
+00:28:19.199 --> 00:28:22.202
+Forgive me, Senator,
+but the man called it "a war without end."
+
+274
+00:28:23.120 --> 00:28:25.289
+Millions of people already dead.
+
+275
+00:28:25.789 --> 00:28:27.708
+Like nothing he's ever seen.
+
+276
+00:28:28.292 --> 00:28:30.294
+Only Ares could do such a thing.
+
+277
+00:28:32.296 --> 00:28:35.382
+We cannot simply let him go.
+We must go with him.
+
+278
+00:28:36.300 --> 00:28:38.218
+I will not deploy our army
+and leave Themyscira defenseless
+
+279
+00:28:38.385 --> 00:28:39.428
+to go and fight their war.
+
+280
+00:28:39.595 --> 00:28:41.471
+It is not their war.
+
+281
+00:28:41.638 --> 00:28:44.808
+Zeus created man to be
+just and wise, strong and passionate--
+
+282
+00:28:44.975 --> 00:28:47.394
+That was a story, Diana!
+
+283
+00:28:47.561 --> 00:28:48.896
+There is much you do not understand.
+
+284
+00:28:49.062 --> 00:28:50.105
+Men are easily corrupted.
+
+285
+00:28:50.272 --> 00:28:53.066
+Yes, but Ares is behind that corruption!
+
+286
+00:28:53.233 --> 00:28:56.111
+It is Ares who has these Germans fighting.
+
+287
+00:28:56.278 --> 00:29:00.324
+<i>And stopping the God of War
+is our foreordinance.</i>
+
+288
+00:29:00.490 --> 00:29:02.910
+As Amazons, this is our duty.
+
+289
+00:29:03.076 --> 00:29:05.913
+But you are not an Amazon
+like the rest of us.
+
+290
+00:29:06.955 --> 00:29:08.415
+So you will do nothing.
+
+291
+00:29:09.082 --> 00:29:10.083
+As your queen, I forbid it.
+
+292
+00:29:23.347 --> 00:29:24.514
+Strange.
+
+293
+00:29:26.350 --> 00:29:28.310
+Is it true you saved his life?
+
+294
+00:29:28.852 --> 00:29:29.853
+Who told you that?
+
+295
+00:29:30.020 --> 00:29:31.021
+He did.
+
+296
+00:29:54.378 --> 00:29:55.379
+Whoa! I...
+
+297
+00:29:57.965 --> 00:29:59.549
+I didn't see you come in.
+
+298
+00:30:04.888 --> 00:30:07.724
+Would you say you're a
+
+299
+00:30:08.558 --> 00:30:11.144
+typical example of your sex?
+
+300
+00:30:11.770 --> 00:30:13.438
+I am
+
+301
+00:30:16.692 --> 00:30:18.402
+above average.
+
+302
+00:30:22.030 --> 00:30:23.156
+What's that?
+
+303
+00:30:25.075 --> 00:30:26.493
+It's a...
+
+304
+00:30:28.537 --> 00:30:29.538
+Oh! Um...
+
+305
+00:30:31.748 --> 00:30:33.667
+It's a watch.
+
+306
+00:30:34.084 --> 00:30:35.085
+A watch?
+
+307
+00:30:35.252 --> 00:30:36.253
+<i>Yeah, it's a watch.</i>
+
+308
+00:30:36.420 --> 00:30:37.838
+It tells time.
+
+309
+00:30:38.839 --> 00:30:40.841
+My father gave it to me.
+
+310
+00:30:42.551 --> 00:30:44.052
+It's been through hell and back with him.
+
+311
+00:30:45.512 --> 00:30:48.473
+Now it's with me,
+and good thing it's still ticking.
+
+312
+00:30:49.516 --> 00:30:50.517
+What for?
+
+313
+00:30:52.436 --> 00:30:54.021
+Because it tells time.
+
+314
+00:30:55.439 --> 00:30:57.941
+When to eat, sleep, wake up, work.
+
+315
+00:30:59.609 --> 00:31:02.487
+You let this little thing
+tell you what to do?
+
+316
+00:31:02.654 --> 00:31:04.114
+Yeah.
+
+317
+00:31:10.620 --> 00:31:12.122
+Can I ask you some questions?
+
+318
+00:31:13.582 --> 00:31:14.958
+<i>- Where are we?</i>
+- Themyscira.
+
+319
+00:31:15.125 --> 00:31:18.628
+No, I got that before.
+But I mean, where are we?
+
+320
+00:31:19.921 --> 00:31:21.214
+What is this place?
+Who are you people?
+
+321
+00:31:21.381 --> 00:31:23.467
+Why does the water do that?
+
+322
+00:31:23.633 --> 00:31:26.136
+<i>How come you don't know what a watch is?
+How come you speak English so well?</i>
+
+323
+00:31:26.303 --> 00:31:28.430
+We speak hundreds of languages.
+
+324
+00:31:29.306 --> 00:31:32.684
+We are the bridge to
+a greater understanding between all men.
+
+325
+00:31:34.895 --> 00:31:35.979
+Right.
+
+326
+00:31:39.441 --> 00:31:42.652
+You know, I didn't get a chance
+to say this, uh, earlier,
+
+327
+00:31:44.071 --> 00:31:48.325
+but thank you for dragging me
+out of the water.
+
+328
+00:31:49.743 --> 00:31:51.161
+Thank you
+
+329
+00:31:51.745 --> 00:31:53.830
+for what you did on the beach.
+
+330
+00:32:01.963 --> 00:32:02.964
+So,
+
+331
+00:32:04.341 --> 00:32:05.717
+you're here to let me go?
+
+332
+00:32:07.135 --> 00:32:10.680
+I tried, but it's not up to me.
+
+333
+00:32:11.223 --> 00:32:13.016
+I even asked them to send me with you.
+
+334
+00:32:15.519 --> 00:32:16.937
+Or anyone.
+
+335
+00:32:17.104 --> 00:32:18.146
+An Amazon.
+
+336
+00:32:18.313 --> 00:32:19.981
+The Amazons.
+
+337
+00:32:20.148 --> 00:32:21.608
+The Amazons?
+
+338
+00:32:21.775 --> 00:32:24.528
+<i>It is our sacred duty to defend the world.</i>
+
+339
+00:32:25.195 --> 00:32:27.030
+And I wish to go.
+
+340
+00:32:29.699 --> 00:32:31.910
+But my mother will not allow it.
+
+341
+00:32:34.329 --> 00:32:35.330
+Well,
+
+342
+00:32:36.873 --> 00:32:38.875
+I can't say I blame her.
+
+343
+00:32:39.042 --> 00:32:40.043
+<i>The way this war is going,</i>
+
+344
+00:32:40.210 --> 00:32:43.130
+I wouldn't want to
+let anyone I care about near it.
+
+345
+00:32:43.296 --> 00:32:45.215
+Then why do you want to go back?
+
+346
+00:32:45.757 --> 00:32:47.801
+I don't think "want" is the word.
+
+347
+00:32:49.678 --> 00:32:52.180
+I guess I gotta try.
+
+348
+00:32:54.057 --> 00:32:56.143
+My father told me once,
+
+349
+00:32:56.309 --> 00:32:58.645
+he said, "If you see something wrong
+happening in the world,
+
+350
+00:32:58.812 --> 00:33:01.523
+you can either do nothing,
+or you can do something."
+
+351
+00:33:03.567 --> 00:33:05.402
+And I already tried "nothing."
+
+352
+00:35:44.311 --> 00:35:45.353
+Nice outfit.
+
+353
+00:35:46.646 --> 00:35:47.731
+Oh, thank you.
+
+354
+00:35:48.481 --> 00:35:51.484
+Now, I will show you the way off the island
+
+355
+00:35:52.068 --> 00:35:53.611
+and you will take me to Ares.
+
+356
+00:35:54.446 --> 00:35:55.447
+Deal.
+
+357
+00:36:04.622 --> 00:36:05.999
+I'm leaving in that?
+
+358
+00:36:06.166 --> 00:36:07.417
+We are.
+
+359
+00:36:08.835 --> 00:36:10.837
+Yeah, we're leaving in that?
+
+360
+00:36:11.004 --> 00:36:12.464
+Do you not know how to sail?
+
+361
+00:36:12.630 --> 00:36:13.757
+Of course I know how to sail.
+
+362
+00:36:13.923 --> 00:36:15.592
+Why wouldn't I know how to sail?
+It's just...
+
+363
+00:36:16.634 --> 00:36:17.969
+It's been a while.
+
+364
+00:36:47.457 --> 00:36:48.958
+I'm going, Mother.
+
+365
+00:36:49.584 --> 00:36:52.754
+I cannot stand by
+while innocent lives are lost.
+
+366
+00:36:53.630 --> 00:36:58.051
+If no one else will defend the world
+from Ares, then I must.
+
+367
+00:36:59.844 --> 00:37:01.179
+I have to go.
+
+368
+00:37:01.346 --> 00:37:02.722
+I know.
+
+369
+00:37:03.890 --> 00:37:06.226
+<i>Or at least I know I cannot stop you.</i>
+
+370
+00:37:11.940 --> 00:37:13.691
+There is so much...
+
+371
+00:37:14.734 --> 00:37:15.944
+So much you do not understand.
+
+372
+00:37:16.111 --> 00:37:17.570
+<i>I understand enough.</i>
+
+373
+00:37:17.737 --> 00:37:21.282
+That I'm willing to fight for those
+who cannot fight for themselves.
+
+374
+00:37:23.993 --> 00:37:25.495
+Like you once did.
+
+375
+00:37:26.162 --> 00:37:28.081
+You know that if you choose to leave,
+
+376
+00:37:29.791 --> 00:37:31.167
+you may never return.
+
+377
+00:37:33.086 --> 00:37:35.004
+Who will I be if I stay?
+
+378
+00:37:43.888 --> 00:37:46.850
+This belonged to
+the greatest warrior in our history,
+
+379
+00:37:47.434 --> 00:37:50.019
+our beloved Antiope.
+
+380
+00:37:50.186 --> 00:37:52.313
+Make sure you are worthy of it.
+
+381
+00:37:53.898 --> 00:37:55.150
+I will.
+
+382
+00:37:58.236 --> 00:38:00.738
+Be careful in the world of men, Diana.
+
+383
+00:38:02.282 --> 00:38:04.659
+They do not deserve you.
+
+384
+00:38:09.247 --> 00:38:12.208
+You have been my greatest love.
+
+385
+00:38:16.296 --> 00:38:17.505
+Today,
+
+386
+00:38:19.549 --> 00:38:21.551
+you are my greatest sorrow.
+
+387
+00:39:00.423 --> 00:39:01.799
+Should you have told her?
+
+388
+00:39:02.675 --> 00:39:07.138
+The more she knows,
+the sooner he'll find her.
+
+389
+00:39:18.775 --> 00:39:20.652
+How long until we reach the war?
+
+390
+00:39:21.861 --> 00:39:23.988
+The war? Which part?
+
+391
+00:39:24.155 --> 00:39:25.406
+The Western Front in France
+
+392
+00:39:25.573 --> 00:39:27.951
+is 400 miles long
+from the Alps to the North Sea.
+
+393
+00:39:29.661 --> 00:39:31.538
+Where the fighting
+is the most intense, then.
+
+394
+00:39:31.704 --> 00:39:34.582
+If you take me there,
+I'm sure I'll find Ares.
+
+395
+00:39:38.503 --> 00:39:40.880
+Ares? As in, the God of War?
+
+396
+00:39:41.047 --> 00:39:45.134
+The God of War is our responsibility.
+Only an Amazon can defeat him.
+
+397
+00:39:46.010 --> 00:39:47.637
+With this.
+
+398
+00:39:49.097 --> 00:39:50.265
+And once I do,
+
+399
+00:39:50.807 --> 00:39:52.433
+the war will end.
+
+400
+00:39:59.566 --> 00:40:01.651
+Look, I appreciate your spirit,
+
+401
+00:40:02.318 --> 00:40:04.362
+<i>but this war is...</i>
+
+402
+00:40:04.529 --> 00:40:06.739
+It's a great big mess.
+
+403
+00:40:07.615 --> 00:40:10.410
+And there's not a whole lot
+you and I can do about that.
+
+404
+00:40:10.577 --> 00:40:13.162
+I mean, we can get back to London,
+and try to get to the men who can.
+
+405
+00:40:13.329 --> 00:40:15.415
+I'm the man who can!
+
+406
+00:40:15.582 --> 00:40:17.375
+And once I find and destroy Ares,
+
+407
+00:40:17.542 --> 00:40:20.169
+the German armies
+will be freed from his influence
+
+408
+00:40:20.336 --> 00:40:23.339
+and they will be good men again,
+and the world will be better.
+
+409
+00:40:27.844 --> 00:40:28.845
+Great.
+
+410
+00:40:29.762 --> 00:40:30.847
+You'll see.
+
+411
+00:40:34.309 --> 00:40:35.351
+What are you doing?
+
+412
+00:40:35.768 --> 00:40:37.854
+Oh, I thought maybe you'd want to
+
+413
+00:40:39.272 --> 00:40:40.398
+get some sleep.
+
+414
+00:40:43.359 --> 00:40:46.529
+And what about you?
+Are you not sleeping?
+
+415
+00:40:46.696 --> 00:40:48.364
+Does the average man not sleep?
+
+416
+00:40:52.493 --> 00:40:55.622
+Yes, we sleep.
+We just don't sleep with, uh...
+
+417
+00:40:55.788 --> 00:40:56.789
+You don't sleep with women?
+
+418
+00:40:56.956 --> 00:40:59.876
+No. I mean, I do sleep with...
+I sleep with...
+
+419
+00:41:01.210 --> 00:41:02.629
+Yes, I do.
+
+420
+00:41:02.795 --> 00:41:05.256
+But, out of the, uh,
+
+421
+00:41:05.465 --> 00:41:07.842
+confines of marriage
+
+422
+00:41:08.009 --> 00:41:09.427
+it's just...
+
+423
+00:41:11.888 --> 00:41:13.890
+It's not polite to assume, you know?
+
+424
+00:41:17.644 --> 00:41:19.103
+"Marriage"?
+
+425
+00:41:19.270 --> 00:41:21.189
+Marriage. Do you not have that on...
+
+426
+00:41:22.440 --> 00:41:23.816
+You go before a judge
+
+427
+00:41:23.983 --> 00:41:28.154
+and you swear to love,
+honor and cherish each other
+
+428
+00:41:28.321 --> 00:41:29.447
+until death do you part.
+
+429
+00:41:30.323 --> 00:41:32.575
+And do they?
+Love each other till death?
+
+430
+00:41:32.742 --> 00:41:34.494
+Not very often, no.
+
+431
+00:41:34.661 --> 00:41:36.079
+Then why do they do it?
+
+432
+00:41:36.871 --> 00:41:39.332
+I have no idea.
+
+433
+00:41:40.166 --> 00:41:41.834
+So, you cannot sleep with me
+unless I marry you.
+
+434
+00:41:42.001 --> 00:41:44.212
+I will sleep with you, if you want.
+I'll sleep right there.
+
+435
+00:41:44.379 --> 00:41:45.463
+<i>There's plenty of room.</i>
+
+436
+00:41:45.630 --> 00:41:48.174
+- Then, fine, if you don't mind...
+- No, it's up to you.
+
+437
+00:41:48.341 --> 00:41:50.760
+I know it's up to me, I'm making
+the choice. I will come sleep with you.
+
+438
+00:41:50.927 --> 00:41:51.928
+Okay.
+
+439
+00:41:54.806 --> 00:41:55.973
+Yeah, just...
+
+440
+00:41:57.266 --> 00:41:58.476
+Okay.
+
+441
+00:42:13.491 --> 00:42:18.121
+You know, where I come from,
+I'm not considered average.
+
+442
+00:42:18.871 --> 00:42:21.082
+You know, being a spy,
+
+443
+00:42:21.249 --> 00:42:24.544
+you have to show a certain amount of
+
+444
+00:42:26.587 --> 00:42:27.797
+vigor.
+
+445
+00:42:31.050 --> 00:42:34.303
+Have you never met a man before?
+What about your father?
+
+446
+00:42:34.470 --> 00:42:36.222
+I had no father.
+
+447
+00:42:36.889 --> 00:42:38.516
+My mother sculpted me from clay
+
+448
+00:42:38.683 --> 00:42:40.810
+and I was brought to life by Zeus.
+
+449
+00:42:44.188 --> 00:42:45.648
+Well, that's neat.
+
+450
+00:42:49.235 --> 00:42:50.653
+<i>Sorry.</i>
+
+451
+00:42:53.156 --> 00:42:54.657
+Where I come from,
+
+452
+00:42:55.908 --> 00:42:58.202
+babies are made differently.
+
+453
+00:42:59.203 --> 00:43:01.038
+You refer to reproductive biology.
+
+454
+00:43:01.205 --> 00:43:02.790
+- Yes, yes.
+- Yeah, I know.
+
+455
+00:43:03.583 --> 00:43:05.126
+I know all about that.
+
+456
+00:43:05.293 --> 00:43:08.129
+I mean, I refer to that,
+and other things.
+
+457
+00:43:09.046 --> 00:43:10.339
+The pleasures of the flesh.
+
+458
+00:43:13.217 --> 00:43:15.136
+Do you know about that?
+
+459
+00:43:16.304 --> 00:43:20.099
+I've read all 12 volumes of Clio's
+<i>Treatises on Bodily Pleasure.</i>
+
+460
+00:43:21.934 --> 00:43:23.978
+- All 12, huh?
+<i>- Mmm-hmm.</i>
+
+461
+00:43:28.608 --> 00:43:30.067
+Did you bring any of those with you?
+
+462
+00:43:30.693 --> 00:43:31.861
+You would not enjoy them.
+
+463
+00:43:32.028 --> 00:43:33.362
+I don't know. Maybe.
+
+464
+00:43:33.529 --> 00:43:34.655
+<i>No, you wouldn't.</i>
+
+465
+00:43:34.822 --> 00:43:36.199
+Why not?
+
+466
+00:43:36.365 --> 00:43:39.494
+They came to the conclusion that men
+are essential for procreation,
+
+467
+00:43:39.660 --> 00:43:41.537
+but when it comes to pleasure,
+
+468
+00:43:41.871 --> 00:43:43.790
+unnecessary.
+
+469
+00:43:43.956 --> 00:43:45.458
+No, no.
+
+470
+00:43:50.087 --> 00:43:51.088
+Good night.
+
+471
+00:43:51.297 --> 00:43:52.548
+Night.
+
+472
+00:44:05.061 --> 00:44:06.687
+How long until we are operational?
+
+473
+00:44:06.854 --> 00:44:08.064
+Two days, sir.
+
+474
+00:44:08.231 --> 00:44:09.899
+You have until tonight, Captain.
+
+475
+00:44:10.066 --> 00:44:14.195
+Sir, the men have had no food,
+no sleep.
+
+476
+00:44:14.362 --> 00:44:16.531
+Do you think I have had
+any food or rest, Captain?
+
+477
+00:44:16.989 --> 00:44:18.616
+Do you hear me making excuses?
+
+478
+00:44:18.783 --> 00:44:19.784
+No.
+
+479
+00:44:19.951 --> 00:44:21.410
+Your men are weak, complacent.
+
+480
+00:44:21.577 --> 00:44:24.539
+You've let them forget that
+an attack can happen at any time,
+
+481
+00:44:24.705 --> 00:44:26.123
+from any quarter!
+
+482
+00:44:26.290 --> 00:44:27.458
+So, let's you and I remind them,
+
+483
+00:44:27.625 --> 00:44:28.626
+shall we?
+
+484
+00:44:43.432 --> 00:44:45.226
+- Doctor.
+- General.
+
+485
+00:44:45.393 --> 00:44:46.394
+Progress?
+
+486
+00:44:46.561 --> 00:44:47.854
+Not enough.
+
+487
+00:44:48.729 --> 00:44:50.690
+It is over, General.
+
+488
+00:44:50.857 --> 00:44:52.733
+Germany is giving up.
+
+489
+00:44:52.900 --> 00:44:56.821
+Von Hindenburg has recommended
+the <i>Kaiser</i> sign the armistice.
+
+490
+00:44:56.988 --> 00:44:59.031
+We have run out of time.
+
+491
+00:45:00.658 --> 00:45:03.452
+As soon as the <i>Kaiser</i>
+sees the newest weapon,
+
+492
+00:45:03.619 --> 00:45:05.329
+he will not sign the armistice.
+
+493
+00:45:05.496 --> 00:45:06.581
+But, without my book--
+
+494
+00:45:06.747 --> 00:45:07.999
+We will get your book!
+
+495
+00:45:08.165 --> 00:45:10.626
+It is you that I believe in. Not it.
+
+496
+00:45:12.003 --> 00:45:15.047
+I know that you can,
+and will, succeed. Hmm.
+
+497
+00:45:16.883 --> 00:45:20.219
+It is what you were put on this earth
+to do.
+
+498
+00:45:23.848 --> 00:45:27.268
+Something did come to me last night.
+
+499
+00:45:27.435 --> 00:45:29.437
+A different type of gas.
+
+500
+00:45:30.354 --> 00:45:31.439
+For you.
+
+501
+00:45:31.981 --> 00:45:33.983
+<i>To restore your strength.</i>
+
+502
+00:46:04.096 --> 00:46:06.432
+<i>I've got it. I've got it!</i>
+
+503
+00:46:07.016 --> 00:46:10.102
+And if it's what I think,
+
+504
+00:46:11.270 --> 00:46:13.105
+it's going to be
+
+505
+00:46:14.690 --> 00:46:16.192
+terrible.
+
+506
+00:46:37.505 --> 00:46:38.673
+<i>Morning!</i>
+
+507
+00:46:39.173 --> 00:46:41.717
+We got lucky, we caught a ride.
+We made some good time.
+
+508
+00:46:41.884 --> 00:46:44.220
+<i>Welcome to jolly old London!</i>
+
+509
+00:46:44.595 --> 00:46:46.013
+It's hideous.
+
+510
+00:46:46.555 --> 00:46:48.015
+Yeah, it's not for everybody.
+
+511
+00:47:10.413 --> 00:47:11.872
+- Morning, darling.
+- What a beauty.
+
+512
+00:47:12.039 --> 00:47:13.040
+Hello, beautiful!
+
+513
+00:47:13.207 --> 00:47:15.710
+Gentlemen, eyes to yourself.
+Thank you so much.
+
+514
+00:47:17.670 --> 00:47:19.630
+Come on! Come on.
+
+515
+00:47:21.173 --> 00:47:22.758
+Why are they holding hands?
+
+516
+00:47:23.050 --> 00:47:25.803
+Uh, probably because they're together.
+
+517
+00:47:28.556 --> 00:47:31.100
+No, no, no. We're not together.
+I mean, in that way.
+
+518
+00:47:31.267 --> 00:47:32.268
+This way.
+
+519
+00:47:32.435 --> 00:47:33.644
+To the war!
+
+520
+00:47:33.811 --> 00:47:36.355
+Well, technically, the war is that way.
+But we gotta go this way first.
+
+521
+00:47:36.522 --> 00:47:38.024
+And where are we going?
+
+522
+00:47:38.190 --> 00:47:39.942
+We gotta get this notebook to my superiors.
+
+523
+00:47:40.109 --> 00:47:41.193
+Hey, hey, hey!
+
+524
+00:47:41.360 --> 00:47:44.488
+No, no, no.
+I let you go, you take me to Ares.
+
+525
+00:47:44.655 --> 00:47:46.407
+We made a deal, Steve Trevor.
+
+526
+00:47:46.574 --> 00:47:47.950
+And a deal is a promise.
+
+527
+00:47:48.117 --> 00:47:49.952
+And a promise is unbreakable.
+
+528
+00:47:50.703 --> 00:47:52.788
+Oh, boy. Damn it. All right.
+
+529
+00:47:54.040 --> 00:47:55.875
+You come with me first to deliver this,
+
+530
+00:47:56.042 --> 00:47:58.335
+and then we'll get you a ticket,
+uh...
+
+531
+00:47:58.586 --> 00:47:59.670
+to the war.
+
+532
+00:47:59.962 --> 00:48:00.963
+Deal?
+
+533
+00:48:02.465 --> 00:48:03.591
+- Let's go.
+- Diana...
+
+534
+00:48:03.758 --> 00:48:04.759
+What are you doing?
+
+535
+00:48:04.925 --> 00:48:06.886
+You can't do that because
+you're not wearing any clothes.
+
+536
+00:48:07.053 --> 00:48:10.306
+Let's go...
+Let's go buy you some clothes.
+
+537
+00:48:10.473 --> 00:48:12.266
+What do these women wear into battle?
+
+538
+00:48:12.433 --> 00:48:13.809
+They don't, uh...
+
+539
+00:48:14.018 --> 00:48:15.603
+A baby!
+
+540
+00:48:16.979 --> 00:48:18.230
+- No, no, no. No babies.
+- Oh... Oh...
+
+541
+00:48:18.397 --> 00:48:20.066
+No, please. No babies.
+
+542
+00:48:20.232 --> 00:48:22.026
+That one's not made out of clay.
+
+543
+00:48:22.359 --> 00:48:23.444
+Come on.
+
+544
+00:48:23.611 --> 00:48:25.613
+Diana! Please.
+
+545
+00:48:40.836 --> 00:48:43.339
+Thank God! You're not dead!
+
+546
+00:48:44.840 --> 00:48:46.467
+Hoorah and huzzah!
+
+547
+00:48:46.634 --> 00:48:48.928
+I did think you were dead
+until I got your call, you know?
+
+548
+00:48:49.512 --> 00:48:51.722
+<i>He's been gone for weeks.
+Not a single word.</i>
+
+549
+00:48:51.889 --> 00:48:52.890
+<i>Very unlike him.</i>
+
+550
+00:48:53.057 --> 00:48:55.476
+I'm introducing myself.
+It's Etta Candy.
+
+551
+00:48:55.643 --> 00:48:57.645
+I'm Steve Trevor's secretary.
+
+552
+00:48:57.812 --> 00:48:59.146
+What is a secretary?
+
+553
+00:48:59.313 --> 00:49:00.689
+Ooh! Well, I do everything.
+
+554
+00:49:00.856 --> 00:49:02.942
+I go where he tells me to go,
+and I do what he tells me to do.
+
+555
+00:49:03.567 --> 00:49:05.986
+Well, where I'm from,
+that's called slavery.
+
+556
+00:49:06.153 --> 00:49:07.279
+I really like her.
+
+557
+00:49:07.446 --> 00:49:08.656
+Fantastic. Ladies, after you.
+
+558
+00:49:08.823 --> 00:49:09.990
+Oh, I do, I like her.
+
+559
+00:49:10.157 --> 00:49:12.076
+And it does rather feel like that,
+
+560
+00:49:12.243 --> 00:49:13.786
+except the pay is very good.
+
+561
+00:49:13.953 --> 00:49:16.288
+We've got our work cut out for us,
+haven't we?
+
+562
+00:49:18.457 --> 00:49:22.378
+Is this what passes for armor
+in your country?
+
+563
+00:49:24.046 --> 00:49:25.214
+"Armor." It's fashion.
+
+564
+00:49:25.381 --> 00:49:26.841
+Keeps our tummies in.
+
+565
+00:49:27.383 --> 00:49:28.634
+Why must you keep them in?
+
+566
+00:49:28.801 --> 00:49:31.053
+Only a woman with no tummy
+would ask that question.
+
+567
+00:49:32.763 --> 00:49:36.308
+Conservative,
+but not entirely un-fun.
+
+568
+00:49:37.560 --> 00:49:38.936
+Try it on, at least.
+
+569
+00:49:39.103 --> 00:49:40.146
+Very well.
+
+570
+00:49:41.438 --> 00:49:43.023
+- Ooh! Ah, ah, ah...
+- No! No, no, no.
+
+571
+00:49:43.399 --> 00:49:44.525
+Ooh!
+
+572
+00:49:49.864 --> 00:49:51.407
+Come on! Oh!
+
+573
+00:50:00.124 --> 00:50:02.918
+How can a woman possibly fight in this?
+
+574
+00:50:03.085 --> 00:50:04.170
+Fight?
+
+575
+00:50:04.336 --> 00:50:05.921
+We use our principles.
+
+576
+00:50:06.088 --> 00:50:07.798
+I mean, that's how
+we're going to get the vote.
+
+577
+00:50:07.965 --> 00:50:11.719
+Although, I am not opposed to
+engaging in a bit of fisticuffs,
+
+578
+00:50:11.886 --> 00:50:13.637
+should the occasion arise.
+
+579
+00:50:14.972 --> 00:50:16.265
+Lovely.
+
+580
+00:50:16.557 --> 00:50:17.558
+Oop!
+
+581
+00:50:17.766 --> 00:50:20.186
+It's itchy. It's choking me.
+
+582
+00:50:21.562 --> 00:50:23.647
+Can't say I blame it.
+
+583
+00:50:23.814 --> 00:50:25.065
+Etta.
+
+584
+00:50:25.232 --> 00:50:26.233
+Where is she?
+
+585
+00:50:26.442 --> 00:50:28.777
+Oh, she's trying on outfit number 226.
+
+586
+00:50:38.621 --> 00:50:41.749
+Miss Candy, the whole point
+was to make her look less
+
+587
+00:50:41.916 --> 00:50:43.083
+<i>distracting.</i>
+
+588
+00:50:45.419 --> 00:50:46.420
+May I?
+
+589
+00:50:51.133 --> 00:50:52.468
+<i>Really? Specs?</i>
+
+590
+00:50:52.635 --> 00:50:54.762
+And suddenly she's not the most
+beautiful woman you've ever seen?
+
+591
+00:51:01.435 --> 00:51:02.645
+Better.
+
+592
+00:51:13.781 --> 00:51:15.115
+Yeah, that's not going to work.
+
+593
+00:51:15.282 --> 00:51:16.992
+Please put the sword down, Diana.
+
+594
+00:51:17.159 --> 00:51:18.160
+Diana!
+
+595
+00:51:19.411 --> 00:51:20.537
+Let me try it by myself.
+
+596
+00:51:20.704 --> 00:51:21.789
+After you, sir.
+
+597
+00:51:31.340 --> 00:51:32.341
+Etta...
+
+598
+00:51:32.758 --> 00:51:35.094
+Why don't I meet you back at the office
+
+599
+00:51:35.261 --> 00:51:37.346
+and, meanwhile,
+I'll take this for safekeeping.
+
+600
+00:51:37.513 --> 00:51:38.514
+Oh, no, I don't think so.
+
+601
+00:51:38.681 --> 00:51:40.432
+You gotta put the sword down, Diana.
+Please.
+
+602
+00:51:40.599 --> 00:51:41.850
+- It doesn't go with the outfit.
+- At all.
+
+603
+00:51:42.017 --> 00:51:44.645
+Put the sword down, first of all.
+
+604
+00:51:47.064 --> 00:51:50.651
+Promise me you will protect it
+with your life.
+
+605
+00:51:51.193 --> 00:51:52.945
+Yes... No.
+
+606
+00:51:53.320 --> 00:51:55.239
+You can trust her. Just hand that over.
+
+607
+00:51:55.406 --> 00:51:57.241
+- Shield.
+- And the shield to her.
+
+608
+00:51:57.408 --> 00:51:58.409
+There we go. Whoa!
+
+609
+00:51:58.575 --> 00:51:59.576
+You got it? Thanks, Etta.
+
+610
+00:51:59.743 --> 00:52:01.662
+This is easy.
+
+611
+00:52:03.038 --> 00:52:04.415
+Oh. There we go.
+
+612
+00:52:32.276 --> 00:52:33.277
+What is it?
+
+613
+00:52:35.112 --> 00:52:37.531
+Hopefully nothing. Come on.
+
+614
+00:52:47.207 --> 00:52:49.251
+- Steve, why are we hiding?
+- Shh! Come on, come on.
+
+615
+00:52:58.802 --> 00:53:00.471
+Captain Trevor.
+
+616
+00:53:01.305 --> 00:53:04.433
+I believe you have something that is
+the property of General Ludendorff.
+
+617
+00:53:06.060 --> 00:53:08.729
+Ah, it's the, uh, bad-guy convention.
+
+618
+00:53:08.937 --> 00:53:11.440
+Give us Dr. Maru's notebook.
+
+619
+00:53:12.066 --> 00:53:13.567
+Where did I put that thing?
+
+620
+00:53:14.610 --> 00:53:17.029
+Stand back!
+
+621
+00:53:27.664 --> 00:53:28.749
+Or maybe not.
+
+622
+00:53:44.807 --> 00:53:45.974
+Tough luck.
+
+623
+00:53:52.147 --> 00:53:54.316
+Is there anything else you want to show me?
+
+624
+00:53:55.651 --> 00:53:56.819
+Where do you think you're going?
+
+625
+00:53:59.405 --> 00:54:00.823
+Oh!
+
+626
+00:54:03.575 --> 00:54:06.286
+I'm sorry. But you are
+clearly under his control.
+
+627
+00:54:06.453 --> 00:54:09.164
+- Diana...
+- Let me help you get free.
+
+628
+00:54:09.331 --> 00:54:10.874
+Where will I find Ares?
+
+629
+00:54:18.215 --> 00:54:20.509
+- He's... He's dead.
+- Hmm.
+
+630
+00:54:21.218 --> 00:54:22.511
+Cyanide.
+
+631
+00:54:31.353 --> 00:54:33.063
+Stay here. I'll be right back.
+
+632
+00:54:33.230 --> 00:54:36.024
+<i>Gentlemen! Gentlemen, please!</i>
+
+633
+00:54:36.859 --> 00:54:40.654
+The sad truth is, the majority of them
+don't even know what they're fighting for!
+
+634
+00:54:40.821 --> 00:54:41.822
+Let him speak!
+
+635
+00:54:41.989 --> 00:54:44.158
+Yes, thank you. Gentlemen...
+
+636
+00:54:44.700 --> 00:54:48.745
+Germany is an immensely proud nation.
+
+637
+00:54:50.038 --> 00:54:51.874
+They will never surrender.
+
+638
+00:54:52.291 --> 00:54:54.918
+Now, look.
+The only way to end this war...
+
+639
+00:54:55.085 --> 00:54:58.422
+Colonel,
+I have to talk to you outside.
+
+640
+00:54:58.589 --> 00:55:00.841
+<i>...and restore world peace</i>
+
+641
+00:55:01.008 --> 00:55:02.551
+is to negotiate
+
+642
+00:55:04.261 --> 00:55:05.971
+an armistice.
+
+643
+00:55:06.555 --> 00:55:08.974
+<i>- There's a woman in here.
+- Um...</i>
+
+644
+00:55:09.141 --> 00:55:10.601
+What's she doing in here?
+Get her out.
+
+645
+00:55:12.478 --> 00:55:13.729
+Get her out.
+
+646
+00:55:14.396 --> 00:55:15.439
+Sorry.
+
+647
+00:55:15.606 --> 00:55:17.900
+Blind sister.
+She got lost on the way to the bathroom.
+
+648
+00:55:18.066 --> 00:55:20.068
+I think it's this way.
+Sorry, guys.
+
+649
+00:55:20.777 --> 00:55:22.946
+Um...
+Our only aim at this time
+
+650
+00:55:23.113 --> 00:55:25.741
+must be to achieve peace,
+
+651
+00:55:25.908 --> 00:55:27.784
+at any cost!
+
+652
+00:55:31.288 --> 00:55:33.582
+Why do they not let him speak?
+He's talking peace.
+
+653
+00:55:33.749 --> 00:55:35.250
+Not right now. Sorry.
+
+654
+00:55:40.088 --> 00:55:42.799
+Trevor, what the hell were you thinking,
+bringing a woman into the Council Chamber?
+
+655
+00:55:42.966 --> 00:55:44.927
+The intel that I brought back
+is time-sensitive.
+
+656
+00:55:45.093 --> 00:55:46.512
+This is one of Dr. Maru's notebooks.
+
+657
+00:55:46.678 --> 00:55:47.679
+Notebook or not--
+
+658
+00:55:47.846 --> 00:55:48.847
+We need to get it to cryptography
+
+659
+00:55:49.014 --> 00:55:50.599
+and I need an immediate audience
+with the generals.
+
+660
+00:55:50.766 --> 00:55:52.935
+You do not just barge in here
+and demand an audience with the Cabinet.
+
+661
+00:55:53.101 --> 00:55:54.645
+Sir, with all due respect,
+what I saw in my last mission
+
+662
+00:55:54.811 --> 00:55:55.854
+could change the course of the war.
+
+663
+00:55:56.021 --> 00:55:57.439
+<i>Captain Trevor!</i>
+
+664
+00:55:59.024 --> 00:56:00.651
+I heard we'd lost you
+on one of your missions,
+
+665
+00:56:00.817 --> 00:56:02.319
+yet here you are,
+back from the dead,
+
+666
+00:56:02.486 --> 00:56:04.404
+and I see you've brought a friend with you.
+
+667
+00:56:04.571 --> 00:56:05.948
+Our deepest apologies
+for the interruption, sir.
+
+668
+00:56:06.114 --> 00:56:07.741
+No, no, no. Nonsense.
+
+669
+00:56:07.908 --> 00:56:09.618
+Thanks to this young woman,
+
+670
+00:56:09.785 --> 00:56:13.288
+the room was finally quiet enough for me
+to get at least a few words in.
+
+671
+00:56:13.455 --> 00:56:15.332
+Sir Patrick Morgan, at your service.
+
+672
+00:56:15.999 --> 00:56:17.960
+Diana, Princess of Themys--
+
+673
+00:56:18.126 --> 00:56:19.962
+"Prince." Diana Prince.
+
+674
+00:56:20.796 --> 00:56:21.838
+She is, uh...
+
+675
+00:56:22.005 --> 00:56:23.006
+And I...
+
+676
+00:56:23.173 --> 00:56:24.216
+Are...
+
+677
+00:56:24.383 --> 00:56:25.384
+Working together.
+
+678
+00:56:25.551 --> 00:56:27.511
+<i>She actually helped me
+bring this, uh, notebook back here.</i>
+
+679
+00:56:27.678 --> 00:56:29.972
+<i>That's from Dr. Maru's lab.</i>
+
+680
+00:56:30.138 --> 00:56:32.808
+I think the information contained inside
+will change the course of the war, sir.
+
+681
+00:56:32.975 --> 00:56:34.810
+My God.
+
+682
+00:56:35.769 --> 00:56:37.813
+- Dr. Poison, herself.
+- Yes.
+
+683
+00:57:07.968 --> 00:57:09.011
+<i>Yes.</i>
+
+684
+00:57:09.678 --> 00:57:11.096
+<i>Intriguing.</i>
+
+685
+00:57:11.263 --> 00:57:12.556
+Any further intelligence?
+
+686
+00:57:12.723 --> 00:57:15.767
+Sadly not, sir.
+Cryptography have had no luck.
+
+687
+00:57:15.934 --> 00:57:17.853
+It seems like it's a mixture
+of two languages,
+
+688
+00:57:18.061 --> 00:57:21.565
+but, as yet, they've failed
+to determine which two languages.
+
+689
+00:57:21.732 --> 00:57:23.358
+Ottoman and Sumerian.
+
+690
+00:57:25.861 --> 00:57:28.238
+Surely, someone else in this room
+knew that.
+
+691
+00:57:28.405 --> 00:57:29.489
+Who is this woman?
+
+692
+00:57:29.656 --> 00:57:31.366
+<i>She's my, um,</i>
+
+693
+00:57:32.034 --> 00:57:33.076
+secretary, sir.
+
+694
+00:57:33.660 --> 00:57:35.912
+And she can understand
+Ottoman and Sumerian?
+
+695
+00:57:36.496 --> 00:57:37.956
+She's a very good secretary.
+
+696
+00:57:38.123 --> 00:57:39.541
+See her out.
+
+697
+00:57:40.167 --> 00:57:42.836
+Sir, if this woman can read it,
+
+698
+00:57:43.003 --> 00:57:44.838
+<i>we should hear what she has to say.</i>
+
+699
+00:57:45.005 --> 00:57:46.715
+Yes, very well.
+
+700
+00:57:52.596 --> 00:57:54.389
+It's a formula
+
+701
+00:57:54.973 --> 00:57:56.433
+for a new kind of gas.
+
+702
+00:57:57.017 --> 00:58:00.520
+Mustard gas.
+Hydrogen-based, instead of sulfur.
+
+703
+00:58:00.687 --> 00:58:01.772
+Hydrogen-based...
+
+704
+00:58:01.938 --> 00:58:04.566
+Gas masks would be useless
+against hydrogen.
+
+705
+00:58:04.733 --> 00:58:07.569
+The book says they plan to release the gas
+
+706
+00:58:07.736 --> 00:58:09.071
+at "the front"?
+
+707
+00:58:09.237 --> 00:58:10.238
+When?
+
+708
+00:58:10.405 --> 00:58:11.573
+It doesn't say.
+
+709
+00:58:12.032 --> 00:58:13.325
+Wait. "Front" of what?
+
+710
+00:58:13.492 --> 00:58:14.493
+Sir,
+
+711
+00:58:14.660 --> 00:58:16.453
+that is the evidence we need.
+
+712
+00:58:16.620 --> 00:58:18.080
+You have to find out
+where they're making that gas.
+
+713
+00:58:18.246 --> 00:58:19.414
+You have to burn it to the ground.
+
+714
+00:58:19.581 --> 00:58:20.582
+Destroy it.
+
+715
+00:58:20.749 --> 00:58:23.293
+Ludendorff was last seen in Belgium.
+
+716
+00:58:23.460 --> 00:58:27.589
+We can't be seen sending troops
+into German-occupied Belgium
+
+717
+00:58:27.756 --> 00:58:30.467
+as we are negotiating their surrender.
+
+718
+00:58:30.634 --> 00:58:32.386
+Sir, I've seen that gas with my own eyes.
+
+719
+00:58:32.552 --> 00:58:35.305
+If it is used,
+it will kill everyone on both sides.
+
+720
+00:58:35.472 --> 00:58:36.515
+They will all die.
+
+721
+00:58:36.682 --> 00:58:39.601
+That is what soldiers do, Captain.
+
+722
+00:58:40.435 --> 00:58:42.187
+<i>Send me in
+with some logistical support.</i>
+
+723
+00:58:42.354 --> 00:58:45.482
+At least give me the chance
+to take out Ludendorff's operation myself.
+
+724
+00:58:45.649 --> 00:58:46.775
+Are you insane?
+
+725
+00:58:46.942 --> 00:58:49.236
+I can't introduce rogue elements
+this late in the game.
+
+726
+00:58:49.403 --> 00:58:50.404
+Sir, I can--
+
+727
+00:58:50.570 --> 00:58:51.780
+<i>Now, more than ever,</i>
+
+728
+00:58:51.947 --> 00:58:55.617
+the armistice is of paramount importance.
+
+729
+00:58:55.784 --> 00:58:59.413
+It must be negotiated, it must be signed,
+and this is...
+
+730
+00:59:00.288 --> 00:59:02.958
+Well, it's the best way
+of stopping the war.
+
+731
+00:59:03.125 --> 00:59:05.127
+Captain, you will do nothing.
+
+732
+00:59:05.293 --> 00:59:07.295
+And that is an order.
+
+733
+00:59:08.255 --> 00:59:09.256
+Yes, sir.
+
+734
+00:59:10.465 --> 00:59:11.466
+I understand, sir.
+
+735
+00:59:12.426 --> 00:59:13.468
+I don't!
+
+736
+00:59:13.927 --> 00:59:15.262
+Diana, I know this is confusing...
+
+737
+00:59:15.429 --> 00:59:17.472
+<i>- It is not confusing! It's unthinkable!</i>
+- Who is this woman?
+
+738
+00:59:17.639 --> 00:59:18.640
+She's with me. She's with us, sir.
+
+739
+00:59:18.807 --> 00:59:19.891
+I am not with you!
+
+740
+00:59:20.058 --> 00:59:23.145
+You would knowingly sacrifice
+all those lives,
+
+741
+00:59:23.311 --> 00:59:24.312
+as if they mean less than yours!
+
+742
+00:59:24.479 --> 00:59:26.148
+- Diana, let's talk about this outside.
+- As if they mean nothing?
+
+743
+00:59:26.314 --> 00:59:29.651
+Where I come from, generals don't
+hide in their offices like cowards.
+
+744
+00:59:29.818 --> 00:59:31.945
+- That's enough!
+- They fight alongside their soldiers.
+
+745
+00:59:32.112 --> 00:59:33.655
+They die with them on the battlefield!
+
+746
+00:59:33.822 --> 00:59:35.198
+- That's enough!
+- You should be ashamed.
+
+747
+00:59:35.365 --> 00:59:37.200
+- My apologies. Diana...
+- You should be ashamed.
+
+748
+00:59:37.367 --> 00:59:38.744
+<i>- Diana...
+- All of you should be ashamed!</i>
+
+749
+00:59:40.162 --> 00:59:41.788
+Please slow down!
+
+750
+00:59:41.955 --> 00:59:43.290
+That's your leader?
+
+751
+00:59:43.457 --> 00:59:45.625
+How could he say that?
+Believe that?
+
+752
+00:59:45.792 --> 00:59:47.210
+And you!
+
+753
+00:59:47.377 --> 00:59:49.171
+Was your duty to simply give them a book?
+
+754
+00:59:49.337 --> 00:59:50.338
+No!
+
+755
+00:59:50.505 --> 00:59:51.673
+You didn't stand your ground!
+You didn't fight!
+
+756
+00:59:51.840 --> 00:59:53.300
+Because there was no chance
+of changing his mind!
+
+757
+00:59:53.467 --> 00:59:56.136
+This is Ares, and he's not going to
+allow a negotiation
+
+758
+00:59:56.303 --> 00:59:57.721
+or a surrender!
+
+759
+00:59:57.888 --> 01:00:00.515
+The millions of people you talked about,
+they will die!
+
+760
+01:00:00.682 --> 01:00:02.142
+We are going anyway!
+
+761
+01:00:04.686 --> 01:00:06.271
+You mean, you were lying?
+
+762
+01:00:06.855 --> 01:00:08.648
+I'm a spy! That's what I do!
+
+763
+01:00:08.815 --> 01:00:09.858
+How do I know
+you're not lying to me right now?
+
+764
+01:00:15.530 --> 01:00:17.032
+I am taking you to the front.
+
+765
+01:00:17.699 --> 01:00:19.743
+We are probably going to die.
+
+766
+01:00:20.660 --> 01:00:22.704
+This is a terrible idea.
+
+767
+01:00:27.375 --> 01:00:29.336
+We're going to need reinforcements.
+
+768
+01:00:39.721 --> 01:00:41.181
+These are the reinforcements?
+
+769
+01:00:41.348 --> 01:00:42.766
+Yup.
+
+770
+01:00:43.183 --> 01:00:44.935
+Are these even good men?
+
+771
+01:00:45.852 --> 01:00:47.062
+Hmm. Relatively.
+
+772
+01:00:48.355 --> 01:00:52.067
+Even in Africa, gentlemen,
+we haven't seen such luxuries.
+
+773
+01:00:52.234 --> 01:00:56.530
+But the luxury that we have now...
+It's like we can't stop making money!
+
+774
+01:00:56.696 --> 01:00:58.949
+So, my uncle, the prince, and I--
+
+775
+01:00:59.115 --> 01:01:01.326
+Boy! Which prince is that?
+
+776
+01:01:01.868 --> 01:01:03.954
+I decide to extend the opportunity
+for a few good soldiers--
+
+777
+01:01:04.120 --> 01:01:05.580
+But, seriously, which prince?
+
+778
+01:01:06.414 --> 01:01:09.417
+Hey, Sultan Angora Mynx Cashmere,
+
+779
+01:01:09.584 --> 01:01:11.253
+<i>could I talk to you for a minute?</i>
+
+780
+01:01:11.586 --> 01:01:13.755
+Gentlemen,
+excuse me one second.
+
+781
+01:01:14.506 --> 01:01:15.507
+"Bar." Well, a "pub."
+
+782
+01:01:15.674 --> 01:01:18.927
+You bugger. I have been greasing
+those peacocks all night, and you...
+
+783
+01:01:19.970 --> 01:01:21.763
+Oh, my goodness gracious.
+
+784
+01:01:22.639 --> 01:01:23.765
+That's a work of art.
+
+785
+01:01:23.932 --> 01:01:25.559
+Sameer, Diana. Diana, Sameer.
+
+786
+01:01:25.725 --> 01:01:27.894
+Hi, Diana.
+You can call me Sammy, please.
+
+787
+01:01:28.061 --> 01:01:29.062
+"Sammy."
+
+788
+01:01:29.229 --> 01:01:31.439
+Sameer, I wouldn't do that,
+if I were you.
+
+789
+01:01:31.606 --> 01:01:32.941
+Sameer's a top undercover man.
+
+790
+01:01:33.108 --> 01:01:35.443
+<i>He can talk the skin off a cat
+in as many languages as you can.</i>
+
+791
+01:01:54.296 --> 01:01:55.380
+Oh, you're done.
+
+792
+01:01:55.547 --> 01:01:56.548
+Where's Charlie?
+
+793
+01:02:00.468 --> 01:02:01.553
+<i>Le voilà.</i>
+
+794
+01:02:04.723 --> 01:02:07.017
+At least this "Charlie"
+is good with his fists.
+
+795
+01:02:07.976 --> 01:02:09.185
+That's not Charlie.
+
+796
+01:02:17.110 --> 01:02:18.153
+That's Charlie.
+
+797
+01:02:22.490 --> 01:02:23.491
+Steven!
+
+798
+01:02:23.950 --> 01:02:26.494
+May God put a flower upon your head, son.
+
+799
+01:02:26.661 --> 01:02:27.954
+Good to see you.
+
+800
+01:02:29.456 --> 01:02:31.499
+<i>So, what were you fighting about?</i>
+
+801
+01:02:32.459 --> 01:02:35.378
+I mistook his glass for mine.
+It happens.
+
+802
+01:02:35.545 --> 01:02:37.130
+This man is no fighter.
+
+803
+01:02:37.297 --> 01:02:39.174
+Charlie is an expert marksman.
+
+804
+01:02:39.674 --> 01:02:40.675
+It means he shoots people.
+
+805
+01:02:40.842 --> 01:02:42.510
+From very far away.
+
+806
+01:02:42.844 --> 01:02:44.304
+They never know what hit them.
+
+807
+01:02:45.972 --> 01:02:48.558
+So, how do you know who you kill
+if you can't see their face?
+
+808
+01:02:48.725 --> 01:02:50.894
+I don't. Trust me, it's better that way.
+
+809
+01:02:51.061 --> 01:02:52.437
+You fight without honor.
+
+810
+01:02:53.021 --> 01:02:54.648
+Who gets paid for honor? Eh?
+
+811
+01:02:55.982 --> 01:02:57.359
+So, what's the job, boss?
+
+812
+01:02:58.860 --> 01:02:59.986
+Uh, two days, tops.
+
+813
+01:03:00.153 --> 01:03:02.572
+We need, uh, supplies
+and passage to Belgium.
+
+814
+01:03:02.739 --> 01:03:03.823
+And what's the going rate?
+
+815
+01:03:03.990 --> 01:03:05.033
+Better be a good pay.
+
+816
+01:03:05.200 --> 01:03:07.327
+Yeah, well, here's the thing.
+
+817
+01:03:08.161 --> 01:03:10.330
+Um, I told you it was going to be quick.
+
+818
+01:03:11.790 --> 01:03:14.334
+And there's a lot to be gained by this.
+
+819
+01:03:14.501 --> 01:03:16.378
+So, it's for a great cause...
+
+820
+01:03:16.795 --> 01:03:17.796
+Uh, freedom...
+
+821
+01:03:18.004 --> 01:03:19.005
+Hmm.
+
+822
+01:03:19.214 --> 01:03:20.590
+Friendship,
+
+823
+01:03:23.176 --> 01:03:24.177
+uh, ending the war, friendship--
+
+824
+01:03:24.344 --> 01:03:25.679
+- Okay, you have no money.
+- No.
+
+825
+01:03:33.353 --> 01:03:34.604
+What?
+
+826
+01:03:34.771 --> 01:03:35.897
+What is this?
+
+827
+01:03:36.064 --> 01:03:37.524
+We're going to drop her off at the front.
+
+828
+01:03:37.691 --> 01:03:39.317
+- "Dropping her off"?
+- Yeah.
+
+829
+01:03:39.943 --> 01:03:42.195
+Listen, sweetheart,
+I'm not going to get myself killed
+
+830
+01:03:42.362 --> 01:03:43.530
+helping a wee lassie out of a ditch.
+
+831
+01:03:43.697 --> 01:03:45.740
+- Know what I mean?
+- Here's the little thief now!
+
+832
+01:03:45.907 --> 01:03:47.909
+We don't need your kind around here.
+
+833
+01:03:58.086 --> 01:03:59.337
+She did it!
+
+834
+01:03:59.921 --> 01:04:02.799
+I'm both frightened and aroused.
+
+835
+01:04:09.097 --> 01:04:10.724
+- Oh, here they are! Sorry I'm late.
+- Sir Patrick!
+
+836
+01:04:10.890 --> 01:04:12.392
+Yes, that's what I was going to mention.
+
+837
+01:04:14.269 --> 01:04:16.062
+- Sir Patrick.
+<i>- Oh, no, no, no.</i>
+
+838
+01:04:16.229 --> 01:04:18.398
+Please, gentlemen, sit.
+Miss Prince, sit.
+
+839
+01:04:22.610 --> 01:04:24.821
+I assume you're here planning something
+
+840
+01:04:24.988 --> 01:04:28.158
+that's going to get you either
+court-martialed or killed.
+
+841
+01:04:28.324 --> 01:04:30.201
+And I assume you're here to stop us.
+
+842
+01:04:30.827 --> 01:04:31.953
+No.
+
+843
+01:04:32.120 --> 01:04:33.788
+Not at all, in fact.
+
+844
+01:04:34.789 --> 01:04:35.790
+Well, look.
+
+845
+01:04:35.957 --> 01:04:37.250
+I was a younger man, once.
+
+846
+01:04:37.417 --> 01:04:40.420
+And, had I been in better health, I'd like
+to think that I might do the same.
+
+847
+01:04:40.628 --> 01:04:41.629
+Hmm.
+
+848
+01:04:41.838 --> 01:04:44.090
+<i>It's a very,
+very honorable thing you're doing.</i>
+
+849
+01:04:44.257 --> 01:04:45.258
+Therefore,
+
+850
+01:04:46.468 --> 01:04:47.802
+I'm here to help.
+
+851
+01:04:48.470 --> 01:04:49.846
+Unofficially, of course.
+
+852
+01:04:50.972 --> 01:04:52.182
+What's your plan?
+
+853
+01:04:53.600 --> 01:04:56.644
+If there's another weapons facility,
+find it and destroy it.
+
+854
+01:04:57.145 --> 01:04:59.105
+Along with Ludendorff and Maru.
+
+855
+01:05:00.356 --> 01:05:03.109
+In that case, to allay suspicion,
+
+856
+01:05:03.777 --> 01:05:07.906
+the charming Etta, here,
+could, uh, run the mission from my office.
+
+857
+01:05:08.490 --> 01:05:09.491
+"Run"...
+
+858
+01:05:11.701 --> 01:05:12.702
+Also,
+
+859
+01:05:13.661 --> 01:05:16.164
+there's enough here for a few days.
+
+860
+01:05:21.669 --> 01:05:22.712
+Thank you, sir.
+
+861
+01:05:22.879 --> 01:05:24.464
+You're very welcome.
+
+862
+01:05:25.006 --> 01:05:27.050
+Take great care, all of you,
+
+863
+01:05:27.217 --> 01:05:28.218
+<i>and good luck.</i>
+
+864
+01:05:39.562 --> 01:05:40.563
+Cheers!
+
+865
+01:05:49.614 --> 01:05:51.533
+Fresh ice cream, made today. Hello, miss.
+
+866
+01:05:51.699 --> 01:05:53.034
+Would you like to buy an ice cream?
+
+867
+01:05:53.201 --> 01:05:54.786
+- Me?
+- Are you hungry?
+
+868
+01:05:54.953 --> 01:05:55.954
+Yes.
+
+869
+01:05:56.162 --> 01:05:57.372
+Thank you.
+
+870
+01:05:57.539 --> 01:05:58.581
+Eight pence, please, sir.
+
+871
+01:05:58.748 --> 01:06:00.041
+Here you go, pal. Keep the change.
+
+872
+01:06:00.208 --> 01:06:02.377
+- Thank you very much, sir.
+- Mmm.
+
+873
+01:06:02.585 --> 01:06:04.045
+- What do you think?
+- It's wonderful!
+
+874
+01:06:04.212 --> 01:06:05.213
+Yeah.
+
+875
+01:06:06.381 --> 01:06:08.842
+- You should be very proud.
+<i>- Thank you very much!</i>
+
+876
+01:06:09.008 --> 01:06:10.385
+You should be very proud.
+
+877
+01:06:13.721 --> 01:06:17.058
+<i>It's a long way to Tipperary</i>
+
+878
+01:06:17.225 --> 01:06:20.603
+<i>It's a long way to go</i>
+
+879
+01:06:20.770 --> 01:06:24.023
+I hope our guy meets us here.
+Chief's expecting us before dark.
+
+880
+01:06:24.732 --> 01:06:25.775
+"Chief"?
+
+881
+01:06:26.776 --> 01:06:28.403
+Uh, yeah. A smuggler.
+
+882
+01:06:29.237 --> 01:06:30.697
+Very reputable.
+
+883
+01:06:31.072 --> 01:06:34.200
+A liar, a murderer, and now a smuggler.
+
+884
+01:06:34.742 --> 01:06:35.743
+Lovely.
+
+885
+01:06:36.244 --> 01:06:37.537
+Careful, I might get offended.
+
+886
+01:06:37.704 --> 01:06:39.247
+I wasn't referring to you.
+
+887
+01:06:39.706 --> 01:06:40.707
+Really?
+
+888
+01:06:40.957 --> 01:06:42.917
+I went undercover
+and pretended to be somebody else,
+
+889
+01:06:43.084 --> 01:06:44.752
+shot people on your beach,
+and smuggled a notebook.
+
+890
+01:06:44.919 --> 01:06:47.422
+Liar, murderer, smuggler.
+Are you still coming?
+
+891
+01:07:07.066 --> 01:07:08.067
+It's awful.
+
+892
+01:07:09.444 --> 01:07:10.945
+That's why we're here.
+
+893
+01:07:29.005 --> 01:07:30.798
+The gas will kill everything.
+
+894
+01:07:30.965 --> 01:07:33.676
+What kind of weapon kills innocents?
+
+895
+01:07:34.135 --> 01:07:35.678
+In this war,
+
+896
+01:07:35.845 --> 01:07:37.180
+every kind.
+
+897
+01:07:42.685 --> 01:07:45.188
+You were absent
+at the council meeting, General.
+
+898
+01:07:45.355 --> 01:07:48.066
+I see you are negotiating the terms
+of the armistice without me.
+
+899
+01:07:48.233 --> 01:07:50.985
+- On the <i>Kaiser's</i> behalf.
+- And on your insistence!
+
+900
+01:07:51.527 --> 01:07:54.614
+We could easily win this war,
+if only you had a little faith.
+
+901
+01:07:54.781 --> 01:07:56.074
+<i>We don't.</i>
+
+902
+01:07:56.241 --> 01:07:57.909
+<i>There are shortages of food,</i>
+
+903
+01:07:58.076 --> 01:07:59.869
+medicine, ammunition.
+
+904
+01:08:00.995 --> 01:08:04.749
+Every hour we delay
+costs thousands of German lives.
+
+905
+01:08:04.916 --> 01:08:07.585
+One attack and the war can be ours!
+
+906
+01:08:10.255 --> 01:08:12.090
+As we speak, my chemist--
+
+907
+01:08:12.257 --> 01:08:14.467
+We stand against you and your
+
+908
+01:08:14.759 --> 01:08:15.760
+witch.
+
+909
+01:08:16.219 --> 01:08:18.096
+Ludendorff, enough!
+
+910
+01:08:19.472 --> 01:08:21.432
+Twenty-four hours from now,
+
+911
+01:08:21.599 --> 01:08:23.685
+this war will end.
+
+912
+01:08:24.269 --> 01:08:25.770
+It is over.
+
+913
+01:08:26.980 --> 01:08:28.564
+It is over for you.
+
+914
+01:08:32.193 --> 01:08:33.736
+It is over for all of you.
+
+915
+01:08:50.628 --> 01:08:51.963
+But the mask won't help.
+
+916
+01:08:52.130 --> 01:08:54.007
+They don't know that.
+
+917
+01:09:08.980 --> 01:09:09.981
+Let's go!
+
+918
+01:09:10.148 --> 01:09:12.442
+Time to stage a demonstration
+for the <i>Kaiser!</i>
+
+919
+01:09:14.902 --> 01:09:15.945
+You're late.
+
+920
+01:09:16.112 --> 01:09:17.488
+<i>Cowboy sneak-attack, Chief!</i>
+
+921
+01:09:18.489 --> 01:09:19.490
+How are you?
+
+922
+01:09:20.325 --> 01:09:21.826
+- Good to see you, pal.
+<i>- Okay, big man!</i>
+
+923
+01:09:24.662 --> 01:09:26.497
+- Good to see you.
+- Ah, yes!
+
+924
+01:09:27.248 --> 01:09:28.750
+Good to see you, my friend.
+
+925
+01:09:29.667 --> 01:09:30.918
+You beauty!
+
+926
+01:09:31.669 --> 01:09:33.046
+Who is this?
+
+927
+01:09:39.844 --> 01:09:41.471
+And I am Diana.
+
+928
+01:09:42.347 --> 01:09:43.389
+Where did you find her?
+
+929
+01:09:43.931 --> 01:09:45.099
+She found me.
+
+930
+01:09:45.683 --> 01:09:47.977
+- I plucked him from the sea.
+<i>- It's a long story.</i>
+
+931
+01:09:48.144 --> 01:09:49.228
+We don't have to talk about that right now.
+
+932
+01:09:49.395 --> 01:09:50.813
+What's there?
+
+933
+01:09:51.981 --> 01:09:53.983
+British tea for the Germans,
+
+934
+01:09:54.150 --> 01:09:56.110
+German beer for the British.
+
+935
+01:09:57.820 --> 01:10:00.198
+And Edgar Rice Burroughs novels for both.
+
+936
+01:10:00.365 --> 01:10:01.407
+And guns!
+
+937
+01:10:03.368 --> 01:10:06.287
+Well, may we get what we want!
+
+938
+01:10:06.454 --> 01:10:07.789
+May we get what we need.
+
+939
+01:10:07.955 --> 01:10:10.208
+But may we never get what we deserve.
+
+940
+01:10:10.375 --> 01:10:11.751
+Bang!
+
+941
+01:10:18.674 --> 01:10:20.009
+Strange thunder.
+
+942
+01:10:21.552 --> 01:10:23.054
+German 77s.
+
+943
+01:10:23.388 --> 01:10:24.722
+Guns. Big ones.
+
+944
+01:10:25.973 --> 01:10:27.308
+It's the front, out there.
+
+945
+01:10:28.643 --> 01:10:30.019
+The evening hate.
+
+946
+01:10:30.728 --> 01:10:32.647
+So, who do you fight for in this war?
+
+947
+01:10:32.814 --> 01:10:33.981
+I don't fight.
+
+948
+01:10:34.148 --> 01:10:36.150
+<i>You're here for profit, then?</i>
+
+949
+01:10:36.526 --> 01:10:38.528
+No better place to be.
+
+950
+01:10:39.862 --> 01:10:41.989
+Nowhere better to be than in a war
+where you don't take a side?
+
+951
+01:10:42.156 --> 01:10:43.324
+<i>I have nowhere else.</i>
+
+952
+01:10:43.866 --> 01:10:45.326
+The last war
+took everything from my people.
+
+953
+01:10:45.493 --> 01:10:46.786
+We have nothing left.
+
+954
+01:10:47.662 --> 01:10:48.871
+At least here,
+
+955
+01:10:49.664 --> 01:10:51.082
+I'm free.
+
+956
+01:10:51.666 --> 01:10:53.543
+Who took that from your people?
+
+957
+01:10:54.168 --> 01:10:55.503
+His people.
+
+958
+01:11:00.550 --> 01:11:01.551
+<i>Don't go...</i>
+
+959
+01:11:02.260 --> 01:11:04.887
+Don't go in. Don't go!
+
+960
+01:11:05.054 --> 01:11:07.348
+<i>Don't! Boys, no!</i>
+
+961
+01:11:07.515 --> 01:11:08.516
+Don't go in there!
+
+962
+01:11:08.683 --> 01:11:10.143
+Shh. You're safe.
+
+963
+01:11:10.309 --> 01:11:12.478
+You're safe. Are you okay?
+
+964
+01:11:12.645 --> 01:11:13.980
+Get off me, woman!
+
+965
+01:11:14.147 --> 01:11:15.690
+Stop making a fuss!
+
+966
+01:11:16.023 --> 01:11:17.191
+God!
+
+967
+01:11:21.279 --> 01:11:23.656
+He sees ghosts.
+
+968
+01:11:28.661 --> 01:11:29.745
+You're going to get cold.
+
+969
+01:11:29.912 --> 01:11:31.038
+Oh, I don't...
+
+970
+01:11:31.497 --> 01:11:33.875
+Don't worry about Charlie.
+He doesn't mean anything by it.
+
+971
+01:11:49.307 --> 01:11:51.476
+<i>Get out of there, now.
+We've got to move!</i>
+
+972
+01:11:51.642 --> 01:11:54.061
+You bloody animal, move!
+Go on! Get on!
+
+973
+01:11:54.228 --> 01:11:56.189
+These animals,
+why are they hurting them?
+
+974
+01:11:56.355 --> 01:11:58.357
+Because they need to move, quick!
+
+975
+01:11:58.524 --> 01:12:00.193
+- Like us!
+- But this is not the way.
+
+976
+01:12:00.902 --> 01:12:02.445
+I could help them.
+
+977
+01:12:02.653 --> 01:12:03.905
+<i>There's no time. Come on, woman!</i>
+
+978
+01:12:07.074 --> 01:12:08.201
+Mama!
+
+979
+01:12:12.997 --> 01:12:14.916
+That man... He's wounded.
+
+980
+01:12:15.082 --> 01:12:17.126
+<i>There is nothing you can do
+about it, Diana.</i>
+
+981
+01:12:17.293 --> 01:12:18.836
+<i>We must keep moving!</i>
+
+982
+01:12:39.857 --> 01:12:41.108
+What is this?
+
+983
+01:12:41.275 --> 01:12:43.319
+You wanted me to take you to the war.
+This is it.
+
+984
+01:12:43.486 --> 01:12:44.862
+So, where are the Germans?
+
+985
+01:12:45.029 --> 01:12:47.448
+A couple hundred yards across the field.
+
+986
+01:12:47.615 --> 01:12:48.950
+- Their trench is...
+- Watch out!
+
+987
+01:12:51.577 --> 01:12:53.746
+Chief! It's good to see you!
+
+988
+01:12:53.913 --> 01:12:56.123
+<i>Oi! Chief's back! He's back!</i>
+
+989
+01:12:57.583 --> 01:12:58.751
+All right, let's move!
+
+990
+01:13:14.559 --> 01:13:17.144
+- Diana, we have to go.
+- We need to help these people.
+
+991
+01:13:17.311 --> 01:13:18.312
+We have to stay on-mission.
+
+992
+01:13:18.479 --> 01:13:19.814
+The next safe crossing
+is at least a day away.
+
+993
+01:13:19.981 --> 01:13:22.400
+- What are we waiting for?
+- We cannot leave without helping them.
+
+994
+01:13:22.567 --> 01:13:24.151
+These people are dying.
+
+995
+01:13:24.318 --> 01:13:25.987
+They have nothing to eat,
+and in the village...
+
+996
+01:13:26.153 --> 01:13:27.572
+- Enslaved, she said!
+- I understand that.
+
+997
+01:13:27.738 --> 01:13:28.739
+Women and children!
+
+998
+01:13:28.906 --> 01:13:30.116
+We need to make
+our next position by sundown.
+
+999
+01:13:30.283 --> 01:13:32.451
+How can you say that?
+What is the matter with you?
+
+1000
+01:13:32.618 --> 01:13:34.662
+This is No Man's Land, Diana!
+
+1001
+01:13:35.246 --> 01:13:37.123
+It means no man can cross it,
+all right?
+
+1002
+01:13:37.290 --> 01:13:39.625
+This battalion has been here
+for nearly a year
+
+1003
+01:13:39.792 --> 01:13:42.169
+and they barely gained an inch.
+
+1004
+01:13:42.336 --> 01:13:45.631
+Because, on the other side,
+there are a bunch of Germans
+
+1005
+01:13:45.798 --> 01:13:47.967
+pointing machine guns at
+every square inch of this place.
+
+1006
+01:13:48.134 --> 01:13:50.386
+This is not something you can cross.
+It's not possible.
+
+1007
+01:13:50.553 --> 01:13:51.929
+So what? So, we do nothing?
+
+1008
+01:13:52.096 --> 01:13:53.848
+No, we are doing something.
+We are.
+
+1009
+01:13:54.015 --> 01:13:55.308
+- We just...
+- Steve.
+
+1010
+01:13:55.474 --> 01:13:56.892
+We can't save everyone in this war.
+
+1011
+01:13:57.059 --> 01:13:58.269
+<i>Steve, Steve...</i>
+
+1012
+01:13:58.978 --> 01:14:00.396
+This is not what we came here to do.
+
+1013
+01:14:16.495 --> 01:14:17.496
+No,
+
+1014
+01:14:17.663 --> 01:14:19.665
+but it's what I'm going to do.
+
+1015
+01:14:34.889 --> 01:14:36.223
+Diana!
+
+1016
+01:14:58.412 --> 01:15:00.706
+What the bloody hell is she playing at?
+
+1017
+01:15:17.098 --> 01:15:19.475
+She's taking all the fire!
+Let's go!
+
+1018
+01:15:22.978 --> 01:15:25.064
+Stay down! Stay down!
+
+1019
+01:15:25.231 --> 01:15:26.607
+<i>That's an order!</i>
+
+1020
+01:16:19.827 --> 01:16:20.661
+Go, now!
+
+1021
+01:16:20.828 --> 01:16:22.747
+<i>She's done it!
+She's got them on the run!</i>
+
+1022
+01:16:26.625 --> 01:16:28.836
+Get down, get down! She's done it!
+
+1023
+01:16:42.558 --> 01:16:43.976
+Steve!
+
+1024
+01:16:44.185 --> 01:16:45.269
+Let's go!
+
+1025
+01:16:48.063 --> 01:16:49.774
+Come on, go!
+
+1026
+01:17:10.044 --> 01:17:11.629
+Stay here. I'll go ahead.
+
+1027
+01:17:47.248 --> 01:17:48.624
+- What the...
+- Let's move!
+
+1028
+01:18:26.954 --> 01:18:28.455
+<i>We need more firepower.</i>
+
+1029
+01:19:44.573 --> 01:19:45.658
+Sniper!
+
+1030
+01:19:45.824 --> 01:19:47.117
+Go!
+
+1031
+01:19:49.328 --> 01:19:50.329
+Get in!
+
+1032
+01:19:50.496 --> 01:19:51.956
+Charlie, bell tower!
+
+1033
+01:20:00.172 --> 01:20:01.173
+<i>Come on, Charlie. Shoot him!</i>
+
+1034
+01:20:02.424 --> 01:20:04.385
+Hey, it's okay.
+
+1035
+01:20:06.720 --> 01:20:07.721
+<i>Huh.</i>
+
+1036
+01:20:09.515 --> 01:20:11.517
+Follow me! Give me some cover!
+
+1037
+01:20:17.690 --> 01:20:19.400
+Right!
+
+1038
+01:20:19.566 --> 01:20:22.277
+We're going to put this on our backs,
+and, when I say go,
+
+1039
+01:20:22.444 --> 01:20:23.404
+- lift hard!
+- Okay.
+
+1040
+01:20:24.446 --> 01:20:26.323
+<i>Diana! Shield!</i>
+
+1041
+01:20:30.411 --> 01:20:31.912
+Go!
+
+1042
+01:21:33.599 --> 01:21:35.642
+<i>Stay very,
+very still for me, my friends.</i>
+
+1043
+01:21:35.809 --> 01:21:37.436
+<i>Please. So important.</i>
+
+1044
+01:21:41.148 --> 01:21:42.441
+Thank you very much.
+
+1045
+01:21:42.608 --> 01:21:45.319
+This has been such an honor for me,
+taking your photograph.
+
+1046
+01:21:45.486 --> 01:21:46.528
+Thank you so much.
+
+1047
+01:21:52.951 --> 01:21:55.245
+<i>For all his talk of shooting,</i>
+
+1048
+01:21:55.412 --> 01:21:56.997
+he cannot shoot.
+
+1049
+01:22:00.084 --> 01:22:02.628
+Not everyone gets to be
+what they want to be all the time.
+
+1050
+01:22:03.170 --> 01:22:05.589
+Me, I am an actor.
+
+1051
+01:22:05.756 --> 01:22:07.132
+I love acting.
+
+1052
+01:22:07.299 --> 01:22:09.009
+I didn't want to be a soldier.
+
+1053
+01:22:10.177 --> 01:22:11.637
+But I'm the wrong color.
+
+1054
+01:22:12.596 --> 01:22:14.932
+Everyone is fighting their own battles,
+Diana.
+
+1055
+01:22:16.350 --> 01:22:17.810
+Just as you are fighting yours.
+
+1056
+01:22:24.024 --> 01:22:25.651
+It's too much.
+I wish you well.
+
+1057
+01:22:25.818 --> 01:22:26.819
+Thank you, thank you.
+
+1058
+01:22:30.989 --> 01:22:32.533
+I'm on the... On the phone--
+
+1059
+01:22:33.033 --> 01:22:35.536
+Uh, it's "Veld." V-E-L-D.
+
+1060
+01:22:35.702 --> 01:22:37.246
+It's a tiny village.
+
+1061
+01:22:37.412 --> 01:22:39.206
+<i>It may not even be on the map.</i>
+
+1062
+01:22:39.373 --> 01:22:40.707
+Ooh! I found it! I found it!
+
+1063
+01:22:41.250 --> 01:22:42.835
+<i>Did you find Ludendorff's operation?</i>
+
+1064
+01:22:43.001 --> 01:22:44.837
+No, no, no. But I located him.
+
+1065
+01:22:45.003 --> 01:22:47.464
+And, oh, lucky you,
+he's only a few miles away,
+
+1066
+01:22:47.631 --> 01:22:49.466
+at German High Command.
+
+1067
+01:22:49.883 --> 01:22:51.552
+<i>German High Command, huh?</i>
+
+1068
+01:22:51.718 --> 01:22:53.345
+So, intel reports
+
+1069
+01:22:53.512 --> 01:22:55.681
+<i>that Ludendorff is hosting a gala.</i>
+
+1070
+01:22:55.848 --> 01:22:57.224
+<i>A sort of "last hurrah"</i>
+
+1071
+01:22:57.391 --> 01:22:59.685
+before the Germans sign the armistice.
+
+1072
+01:22:59.852 --> 01:23:02.563
+And the <i>Kaiser</i> himself
+is going to be there.
+
+1073
+01:23:03.063 --> 01:23:05.607
+As well as Dr. Maru.
+
+1074
+01:23:06.233 --> 01:23:07.693
+Actually, the gala could be perfect cover.
+
+1075
+01:23:07.860 --> 01:23:09.570
+<i>- Captain Trevor.</i>
+- Yes, sir.
+
+1076
+01:23:09.736 --> 01:23:12.322
+<i>You are, under no circumstances,
+to go anywhere near</i>
+
+1077
+01:23:12.489 --> 01:23:14.533
+that gala tomorrow night.
+Do you hear me?
+
+1078
+01:23:14.700 --> 01:23:16.702
+<i>You'd be jeopardizing
+everything we've worked for.</i>
+
+1079
+01:23:16.869 --> 01:23:19.204
+<i>You cannot compromise the armistice.</i>
+
+1080
+01:23:19.371 --> 01:23:20.998
+- Sir, there will be no armistice...
+- Steve!
+
+1081
+01:23:21.165 --> 01:23:23.000
+...once Ludendorff bombs
+the entire front line.
+
+1082
+01:23:23.167 --> 01:23:24.168
+Hold on one second, sir.
+
+1083
+01:23:24.334 --> 01:23:26.211
+You shouldn't be bothered
+about upsetting the peace accord.
+
+1084
+01:23:26.378 --> 01:23:28.213
+- Why not?
+- Ares would never let...
+
+1085
+01:23:28.672 --> 01:23:29.673
+What?
+
+1086
+01:23:30.215 --> 01:23:31.216
+What is it?
+
+1087
+01:23:31.758 --> 01:23:33.719
+Of course. It makes complete sense.
+
+1088
+01:23:35.220 --> 01:23:38.307
+Ares developed a weapon,
+the worst ever devised.
+
+1089
+01:23:38.473 --> 01:23:40.225
+- Ares? You mean Ludendorff.
+- No.
+
+1090
+01:23:40.767 --> 01:23:42.186
+I mean Ares.
+
+1091
+01:23:42.769 --> 01:23:44.188
+Ludendorff is Ares!
+
+1092
+01:23:45.814 --> 01:23:47.566
+Sir, this is our last chance,
+
+1093
+01:23:47.733 --> 01:23:49.484
+our final chance
+to find out where the gas is
+
+1094
+01:23:49.651 --> 01:23:51.445
+and to learn how Ludendorff
+plans on delivering it.
+
+1095
+01:23:51.612 --> 01:23:53.363
+No, no, no. I forbid it.
+
+1096
+01:23:53.530 --> 01:23:54.740
+Do you hear me? I forbid it.
+
+1097
+01:23:54.907 --> 01:23:56.783
+Sir, I'm losing you! Sir?
+
+1098
+01:23:56.950 --> 01:23:57.951
+<i>- Hello?</i>
+- Sir...
+
+1099
+01:24:01.246 --> 01:24:02.956
+How likely is he to respect my wishes?
+
+1100
+01:24:03.123 --> 01:24:05.292
+Not very likely, I'll be honest.
+
+1101
+01:24:11.590 --> 01:24:13.258
+Sammy. Sammy, no. No, no, no.
+
+1102
+01:24:13.425 --> 01:24:15.302
+Sammy, I have to work.
+
+1103
+01:24:15.469 --> 01:24:16.637
+I gotta rustle up a German uniform.
+
+1104
+01:24:16.803 --> 01:24:18.096
+I still have to plot the course
+for tomorrow.
+
+1105
+01:24:18.263 --> 01:24:19.890
+That's easy, boss. Come on.
+
+1106
+01:24:20.057 --> 01:24:21.433
+There is nothing we can do until tomorrow.
+
+1107
+01:24:21.600 --> 01:24:22.643
+You said it yourself, Steve.
+
+1108
+01:24:22.809 --> 01:24:24.811
+So<i>... Madame, s'il vous plaît.</i>
+
+1109
+01:24:24.978 --> 01:24:25.979
+<i>Incroyable!</i>
+
+1110
+01:24:26.730 --> 01:24:28.232
+<i>Magnifique!</i>
+
+1111
+01:24:28.440 --> 01:24:29.441
+- Thank you.
+- Thank you.
+
+1112
+01:24:29.608 --> 01:24:30.817
+<i>Monsieur, s'il vous plaît.</i>
+
+1113
+01:24:32.945 --> 01:24:34.363
+<i>- Et voilà!</i>
+- Merci, <i>Sammy.</i>
+
+1114
+01:24:34.529 --> 01:24:35.530
+<i>Et voilà!</i>
+
+1115
+01:24:47.876 --> 01:24:49.169
+You did this.
+
+1116
+01:24:51.463 --> 01:24:52.464
+We did.
+
+1117
+01:24:57.427 --> 01:24:58.845
+Do you have dancing on
+
+1118
+01:24:59.721 --> 01:25:01.014
+Paradise Island?
+
+1119
+01:25:01.181 --> 01:25:02.975
+Dancing, yeah. Of course.
+
+1120
+01:25:03.141 --> 01:25:07.187
+But these people are just swaying.
+
+1121
+01:25:08.021 --> 01:25:11.400
+Okay, if you're going to be fighting
+the God of War,
+
+1122
+01:25:11.566 --> 01:25:14.528
+I may as well teach you how to dance,
+you poor thing.
+
+1123
+01:25:14.695 --> 01:25:17.364
+All right, probably without the gun.
+
+1124
+01:25:17.531 --> 01:25:18.782
+<i>Madame.</i>
+
+1125
+01:25:21.535 --> 01:25:23.078
+If you would.
+
+1126
+01:25:23.745 --> 01:25:24.746
+Well...
+
+1127
+01:25:26.498 --> 01:25:28.709
+If I'm going to a gala,
+I'll need to know how to dance.
+
+1128
+01:25:28.875 --> 01:25:30.585
+- You're not going to the gala.
+- Of course I am.
+
+1129
+01:25:30.752 --> 01:25:32.629
+- No, you're not.
+- Why wouldn't I?
+
+1130
+01:25:32.796 --> 01:25:34.798
+Well, for one,
+you don't know how to dance.
+
+1131
+01:25:35.340 --> 01:25:37.718
+I would argue that
+they don't know how to dance.
+
+1132
+01:25:37.884 --> 01:25:39.177
+Be polite, be polite.
+
+1133
+01:25:41.888 --> 01:25:44.308
+All right. So, give me your hand.
+
+1134
+01:25:44.474 --> 01:25:45.517
+Like so.
+
+1135
+01:25:46.226 --> 01:25:49.438
+And I'm gonna put my arm
+
+1136
+01:25:49.604 --> 01:25:51.356
+around you, like so.
+
+1137
+01:25:52.024 --> 01:25:53.984
+And we just...
+
+1138
+01:25:54.151 --> 01:25:55.610
+What did you call it? "Sway"?
+
+1139
+01:25:55.777 --> 01:25:56.903
+Then you just sway.
+
+1140
+01:25:57.487 --> 01:25:58.989
+You're awfully close.
+
+1141
+01:26:01.116 --> 01:26:03.243
+That's what it's all about.
+
+1142
+01:26:06.121 --> 01:26:07.331
+I see.
+
+1143
+01:26:16.298 --> 01:26:18.550
+I haven't heard him sing in years.
+
+1144
+01:26:35.067 --> 01:26:37.903
+It's, uh... It's a snowfall.
+
+1145
+01:26:42.282 --> 01:26:43.283
+Touch it.
+
+1146
+01:26:46.411 --> 01:26:47.913
+It's magical!
+
+1147
+01:26:48.914 --> 01:26:50.624
+It is, isn't it?
+
+1148
+01:26:52.667 --> 01:26:54.086
+It is, yeah.
+
+1149
+01:27:00.634 --> 01:27:04.054
+Is this what people do
+when there are no wars to fight?
+
+1150
+01:27:04.763 --> 01:27:05.764
+Yeah.
+
+1151
+01:27:07.057 --> 01:27:10.143
+Yeah, this and other things.
+
+1152
+01:27:10.310 --> 01:27:11.728
+What things?
+
+1153
+01:27:13.647 --> 01:27:14.648
+Um...
+
+1154
+01:27:19.152 --> 01:27:20.654
+They have breakfast.
+
+1155
+01:27:21.238 --> 01:27:22.864
+They really love a breakfast.
+
+1156
+01:27:23.031 --> 01:27:25.575
+And, um, they love to wake up
+
+1157
+01:27:26.535 --> 01:27:28.745
+and read the paper and go to work.
+
+1158
+01:27:29.830 --> 01:27:31.581
+They get married.
+
+1159
+01:27:32.207 --> 01:27:33.959
+Make some babies,
+grow old together.
+
+1160
+01:27:34.709 --> 01:27:35.794
+I guess.
+
+1161
+01:27:39.756 --> 01:27:41.258
+What is it like?
+
+1162
+01:27:45.262 --> 01:27:46.763
+I have no idea.
+
+1163
+01:29:21.733 --> 01:29:23.151
+The villagers gave them to us.
+
+1164
+01:29:24.069 --> 01:29:26.780
+- A gracious gift.
+- And they call us heroes.
+
+1165
+01:29:26.947 --> 01:29:27.948
+You are.
+
+1166
+01:29:28.740 --> 01:29:30.534
+Hey, fellas. I know that
+
+1167
+01:29:31.785 --> 01:29:33.453
+I said this job was two days,
+
+1168
+01:29:35.664 --> 01:29:36.748
+and a deal's a deal.
+
+1169
+01:29:39.000 --> 01:29:40.502
+You'd get lost without us.
+
+1170
+01:29:41.419 --> 01:29:42.420
+Yeah.
+
+1171
+01:29:43.213 --> 01:29:45.006
+<i>We all know Diana is capable
+of taking care of herself.</i>
+
+1172
+01:29:45.590 --> 01:29:47.175
+I'm worried that you won't make it.
+
+1173
+01:29:47.342 --> 01:29:48.635
+There's no more money.
+
+1174
+01:29:48.802 --> 01:29:50.220
+We've been paid enough.
+
+1175
+01:29:50.804 --> 01:29:52.722
+Maybe you're better off without me, yeah?
+
+1176
+01:29:53.723 --> 01:29:55.308
+No, Charlie.
+
+1177
+01:29:56.768 --> 01:29:58.853
+Who will sing for us?
+
+1178
+01:29:59.646 --> 01:30:01.773
+<i>- Yeah.</i>
+- Oh, no, please.
+
+1179
+01:30:02.649 --> 01:30:03.900
+Sing?
+
+1180
+01:30:04.109 --> 01:30:05.819
+You asked for it.
+
+1181
+01:30:05.986 --> 01:30:09.114
+<i>Green grow the rashes, O</i>
+
+1182
+01:30:09.406 --> 01:30:12.993
+<i>Green grow the rashes, O</i>
+
+1183
+01:30:13.159 --> 01:30:16.830
+<i>The sweetest hours I e'er did spend</i>
+
+1184
+01:30:17.831 --> 01:30:20.000
+You must think I was born yesterday.
+
+1185
+01:30:20.166 --> 01:30:22.043
+I know it sounds crazy,
+but it's true.
+
+1186
+01:30:22.210 --> 01:30:23.378
+Every word.
+
+1187
+01:30:23.753 --> 01:30:25.130
+Wait, wait, wait.
+
+1188
+01:30:25.297 --> 01:30:27.215
+There is a whole island of women like her?
+
+1189
+01:30:27.382 --> 01:30:29.175
+And not a single man among them?
+
+1190
+01:30:30.176 --> 01:30:31.428
+How do we get there?
+
+1191
+01:30:31.720 --> 01:30:33.680
+<i>And she thinks</i>
+
+1192
+01:30:33.847 --> 01:30:35.890
+that Ludendorff is Ares, the God of War?
+
+1193
+01:30:36.057 --> 01:30:38.935
+And only by killing him
+will the war end? Don't be daft.
+
+1194
+01:30:39.102 --> 01:30:40.520
+<i>You saw what happened out there.</i>
+
+1195
+01:30:41.021 --> 01:30:43.106
+<i>The way she charged
+that machine-gun nest?</i>
+
+1196
+01:30:43.273 --> 01:30:45.066
+The way she took out that tower?
+
+1197
+01:30:46.568 --> 01:30:47.902
+Maybe it's true.
+
+1198
+01:30:49.070 --> 01:30:50.405
+I think it's true.
+
+1199
+01:30:50.864 --> 01:30:51.906
+I believe it's true.
+
+1200
+01:30:52.073 --> 01:30:53.074
+<i>Et voilà.</i>
+
+1201
+01:30:53.241 --> 01:30:57.037
+Steven, son, you don't really believe
+this rubbish, do you?
+
+1202
+01:31:20.226 --> 01:31:22.562
+Diana! Diana!
+Hiding, hiding.
+
+1203
+01:31:24.397 --> 01:31:25.815
+How the hell do we get into that?
+
+1204
+01:31:26.900 --> 01:31:29.653
+I see only a couple of guards
+on the door to distract.
+
+1205
+01:31:29.861 --> 01:31:31.237
+Yeah, it won't look suspicious at all
+
+1206
+01:31:31.404 --> 01:31:32.906
+when I come sauntering
+out of the woods on foot.
+
+1207
+01:31:33.073 --> 01:31:34.074
+I could get in.
+
+1208
+01:31:34.240 --> 01:31:35.742
+You're not going in. It's too dangerous.
+
+1209
+01:31:35.909 --> 01:31:37.494
+- Too dangerous?
+- Yes, too dangerous.
+
+1210
+01:31:37.661 --> 01:31:38.745
+And you're too distracting.
+
+1211
+01:31:38.912 --> 01:31:41.373
+So, look, I'll go in there,
+and follow them
+
+1212
+01:31:41.539 --> 01:31:43.958
+to wherever they're working on the gas
+or, better yet, where it is.
+
+1213
+01:31:44.167 --> 01:31:45.418
+- Then I'm coming with you.
+<i>- No, you're not!</i>
+
+1214
+01:31:45.585 --> 01:31:48.421
+What you're wearing
+isn't exactly undercover.
+
+1215
+01:31:48.588 --> 01:31:49.589
+I don't know.
+
+1216
+01:31:49.756 --> 01:31:51.591
+I would say she was pretty undercover
+on that battlefield.
+
+1217
+01:31:51.758 --> 01:31:53.802
+<i>We just...
+We can't get you in, okay?</i>
+
+1218
+01:31:53.968 --> 01:31:55.387
+So, I'll scout it out, report back, and--
+
+1219
+01:31:55.553 --> 01:31:57.430
+But as long as he's still alive,
+it doesn't--
+
+1220
+01:31:57.597 --> 01:32:00.058
+You cannot go into German High Command
+and kill anyone.
+
+1221
+01:32:00.225 --> 01:32:02.102
+You just can't. You have to trust me.
+
+1222
+01:32:03.436 --> 01:32:05.271
+- Oh, wow!
+- Where did that come from?
+
+1223
+01:32:05.438 --> 01:32:07.482
+Oh, can I drive it?
+Please, let me drive it!
+
+1224
+01:32:07.649 --> 01:32:08.900
+I'll be your chauffeur.
+
+1225
+01:32:09.067 --> 01:32:10.276
+Come on, come on.
+
+1226
+01:32:11.027 --> 01:32:12.028
+Stay put!
+
+1227
+01:32:12.862 --> 01:32:13.863
+<i>Where did this come from?</i>
+
+1228
+01:32:14.030 --> 01:32:16.199
+A field over there. It's full of them!
+
+1229
+01:32:20.787 --> 01:32:21.871
+Chief, I say you and me scope out the area
+
+1230
+01:32:22.038 --> 01:32:23.581
+in case we need to beat a hasty retreat.
+
+1231
+01:32:23.748 --> 01:32:26.126
+- What do you say, Diana?
+- Huh?
+
+1232
+01:32:30.630 --> 01:32:31.840
+<i>Colonel.</i>
+
+1233
+01:32:35.802 --> 01:32:38.388
+Steve, they have invitations.
+
+1234
+01:32:39.806 --> 01:32:42.183
+Don't worry, play it cool.
+You got this. You got this.
+
+1235
+01:32:46.479 --> 01:32:47.522
+Your invitation, please.
+
+1236
+01:32:47.689 --> 01:32:48.690
+<i>Dhanyavaad,</i> sahib.
+
+1237
+01:32:48.898 --> 01:32:50.483
+The colonel and I wish for many blessings
+
+1238
+01:32:50.650 --> 01:32:52.736
+and all manner of other things
+to fall upon your head.
+
+1239
+01:32:52.902 --> 01:32:54.446
+Your head must be empty.
+
+1240
+01:32:54.654 --> 01:32:56.531
+He wants my invitation, you idiot.
+
+1241
+01:32:56.698 --> 01:32:57.866
+I'm sorry. I'm so sorry.
+
+1242
+01:32:58.032 --> 01:33:00.493
+I must apologize
+a thousand, thousand times, my master.
+
+1243
+01:33:00.702 --> 01:33:03.663
+I make the most horrible,
+the most unforgivable mistake.
+
+1244
+01:33:03.830 --> 01:33:04.956
+I lost the colonel's invitation.
+
+1245
+01:33:05.123 --> 01:33:06.124
+What?
+
+1246
+01:33:06.291 --> 01:33:09.002
+Are you saying we drove all the way
+through the mud and rain
+
+1247
+01:33:09.169 --> 01:33:10.754
+- only for you to lose my invitation?
+- I'm a snail.
+
+1248
+01:33:10.920 --> 01:33:12.005
+No! I'm a bug.
+
+1249
+01:33:12.172 --> 01:33:14.048
+Not even a bug.
+I am the dung of a bug!
+
+1250
+01:33:14.215 --> 01:33:15.467
+And you're right, master...
+
+1251
+01:33:16.176 --> 01:33:17.510
+Blessing be upon us.
+
+1252
+01:33:28.229 --> 01:33:29.606
+<i>This is ridiculous.</i>
+
+1253
+01:33:29.773 --> 01:33:31.941
+<i>I'm not going to spend
+the entire evening out here,</i>
+
+1254
+01:33:32.108 --> 01:33:34.194
+you stupid idiots! Move your cars!
+
+1255
+01:33:55.423 --> 01:33:56.925
+What are you supposed to be?
+
+1256
+01:34:00.595 --> 01:34:02.222
+What are you doing?
+
+1257
+01:34:27.038 --> 01:34:28.081
+Excuse me.
+
+1258
+01:34:30.917 --> 01:34:32.252
+I don't drink.
+
+1259
+01:34:40.426 --> 01:34:41.594
+Have we met?
+
+1260
+01:34:41.761 --> 01:34:43.596
+No, but I've been watching you.
+
+1261
+01:34:44.597 --> 01:34:46.057
+Following your career, I mean.
+
+1262
+01:34:47.433 --> 01:34:49.936
+<i>You are Dr. Isabel Maru.</i>
+
+1263
+01:34:50.103 --> 01:34:52.647
+The most talented chemist
+in the German Army.
+
+1264
+01:34:52.814 --> 01:34:54.440
+I am a fan.
+
+1265
+01:35:05.326 --> 01:35:07.453
+I hope I am not crossing a line.
+
+1266
+01:35:08.955 --> 01:35:11.374
+I know you and General Ludendorff are
+
+1267
+01:35:11.541 --> 01:35:12.584
+very close.
+
+1268
+01:35:12.750 --> 01:35:16.004
+We work well together. Yes.
+
+1269
+01:35:16.838 --> 01:35:19.799
+But having someone like me behind you,
+
+1270
+01:35:20.466 --> 01:35:22.093
+I could provide a lot more.
+
+1271
+01:35:22.260 --> 01:35:24.137
+And who are you?
+
+1272
+01:35:24.721 --> 01:35:28.683
+A man who would show you appreciation
+a genius like yourself deserves.
+
+1273
+01:35:35.148 --> 01:35:37.650
+I love fire. Don't you?
+
+1274
+01:35:40.153 --> 01:35:41.821
+It is like
+
+1275
+01:35:43.156 --> 01:35:45.283
+a living act of entropy.
+
+1276
+01:35:45.450 --> 01:35:47.827
+The ultimate weapon of destruction.
+
+1277
+01:35:48.745 --> 01:35:50.955
+Reminding us that, in the end,
+
+1278
+01:35:51.456 --> 01:35:54.834
+everything eventually
+returns to the ash it came from.
+
+1279
+01:35:57.337 --> 01:35:59.797
+There is something reassuring about it.
+
+1280
+01:36:05.094 --> 01:36:07.305
+I see all of that in your eyes.
+
+1281
+01:36:10.767 --> 01:36:13.061
+Perhaps you could show me
+what you're working on.
+
+1282
+01:36:29.118 --> 01:36:30.620
+<i>I hear it is...</i>
+
+1283
+01:36:32.872 --> 01:36:35.124
+I hear it is extraordinary.
+
+1284
+01:36:35.917 --> 01:36:39.587
+I appreciate your interest in my work,
+
+1285
+01:36:39.754 --> 01:36:42.048
+<i>but I am loyal to General Ludendorff.</i>
+
+1286
+01:36:42.215 --> 01:36:43.216
+<i>Besides,</i>
+
+1287
+01:36:43.758 --> 01:36:46.469
+now I see your attention is
+
+1288
+01:36:49.639 --> 01:36:50.682
+elsewhere.
+
+1289
+01:37:14.706 --> 01:37:16.582
+Enjoying the party?
+
+1290
+01:37:18.584 --> 01:37:21.587
+I confess, I'm not sure what it is
+we're celebrating.
+
+1291
+01:37:21.754 --> 01:37:24.507
+A German victory, of course.
+
+1292
+01:37:24.674 --> 01:37:25.675
+Victory?
+
+1293
+01:37:25.842 --> 01:37:28.052
+When I hear peace could be so close.
+
+1294
+01:37:28.261 --> 01:37:29.262
+Peace?
+
+1295
+01:37:29.429 --> 01:37:31.556
+There's only an armistice
+
+1296
+01:37:31.723 --> 01:37:33.725
+in an endless war.
+
+1297
+01:37:33.891 --> 01:37:35.268
+Thucydides.
+
+1298
+01:37:35.476 --> 01:37:37.437
+Ah! You know your Ancient Greeks.
+
+1299
+01:37:37.603 --> 01:37:39.439
+They understood
+
+1300
+01:37:39.605 --> 01:37:41.941
+that war is a god.
+
+1301
+01:37:42.108 --> 01:37:43.776
+A god that requires human sacrifice.
+
+1302
+01:37:43.943 --> 01:37:45.862
+And in exchange,
+
+1303
+01:37:46.029 --> 01:37:47.780
+war gives man purpose,
+
+1304
+01:37:48.364 --> 01:37:50.575
+meaning, a chance to rise above
+
+1305
+01:37:50.742 --> 01:37:53.036
+his petty, mortal, little self
+
+1306
+01:37:53.619 --> 01:37:54.912
+and be courageous,
+
+1307
+01:37:55.663 --> 01:37:57.165
+noble, better!
+
+1308
+01:37:58.166 --> 01:38:01.461
+Only one of the many gods believed in that.
+
+1309
+01:38:01.878 --> 01:38:04.047
+- Mmm.
+- And he was wrong.
+
+1310
+01:38:05.256 --> 01:38:07.175
+You know nothing of the gods.
+
+1311
+01:38:07.341 --> 01:38:08.551
+<i>Herr</i> General.
+
+1312
+01:38:11.471 --> 01:38:13.014
+Enjoy the fireworks.
+
+1313
+01:38:18.561 --> 01:38:19.645
+What are you doing?
+
+1314
+01:38:19.812 --> 01:38:21.189
+- Out of my way!
+- Diana, look at me.
+
+1315
+01:38:21.355 --> 01:38:23.024
+If you kill Ludendorff
+before we find the gas,
+
+1316
+01:38:23.191 --> 01:38:24.400
+we won't be able to stop anything.
+
+1317
+01:38:24.567 --> 01:38:25.568
+I will stop Ares!
+
+1318
+01:38:25.735 --> 01:38:26.819
+What if you're wrong?
+
+1319
+01:38:28.488 --> 01:38:30.156
+What if there is no Ares?
+
+1320
+01:38:31.949 --> 01:38:33.326
+You don't believe me.
+
+1321
+01:38:33.868 --> 01:38:35.536
+I can't let you do this.
+
+1322
+01:38:36.120 --> 01:38:37.413
+What I do is not up to you.
+
+1323
+01:38:44.212 --> 01:38:45.296
+Diana!
+
+1324
+01:38:49.717 --> 01:38:50.968
+<i>Diana...</i>
+
+1325
+01:38:51.135 --> 01:38:52.220
+<i>It's the gas.</i>
+
+1326
+01:38:52.386 --> 01:38:54.430
+The village... The village!
+
+1327
+01:38:57.391 --> 01:38:58.976
+What are they cheering for?
+
+1328
+01:39:01.521 --> 01:39:02.688
+Diana!
+
+1329
+01:39:05.108 --> 01:39:06.734
+What did they fire?
+
+1330
+01:39:06.901 --> 01:39:07.902
+The gas.
+
+1331
+01:39:08.069 --> 01:39:09.612
+- It was Ludendorff.
+- I saw him. He was in the tower.
+
+1332
+01:39:09.779 --> 01:39:11.948
+Wherever he goes, you follow.
+
+1333
+01:39:12.532 --> 01:39:13.783
+How will you find us?
+
+1334
+01:39:14.367 --> 01:39:15.576
+I know how.
+
+1335
+01:40:33.362 --> 01:40:34.697
+Diana!
+
+1336
+01:40:37.825 --> 01:40:40.494
+They're dead. They're all dead.
+
+1337
+01:40:41.329 --> 01:40:42.955
+I could have saved them.
+
+1338
+01:40:43.289 --> 01:40:45.666
+I could have saved them
+if it weren't for you.
+
+1339
+01:40:45.833 --> 01:40:47.793
+You stopped me from killing Ares!
+
+1340
+01:40:48.336 --> 01:40:50.463
+- No!
+- Stay away from me!
+
+1341
+01:40:50.630 --> 01:40:51.964
+<i>I understand everything now.</i>
+
+1342
+01:40:52.131 --> 01:40:53.966
+It isn't just the Germans
+that Ares has corrupted.
+
+1343
+01:40:54.133 --> 01:40:55.301
+It's you, too.
+
+1344
+01:40:55.927 --> 01:40:57.053
+All of you.
+
+1345
+01:40:58.179 --> 01:40:59.555
+I will find Ares
+
+1346
+01:40:59.722 --> 01:41:01.349
+and I will kill him.
+
+1347
+01:41:04.477 --> 01:41:05.478
+Diana!
+
+1348
+01:41:06.771 --> 01:41:08.022
+That smoke,
+
+1349
+01:41:09.023 --> 01:41:10.149
+<i>it's the Chief!</i>
+
+1350
+01:41:10.316 --> 01:41:11.567
+He followed Ludendorff.
+
+1351
+01:41:13.069 --> 01:41:14.654
+Follow the smoke!
+
+1352
+01:41:40.805 --> 01:41:42.348
+Hey! Diana, that way!
+
+1353
+01:41:58.739 --> 01:42:00.616
+Come on! Let's go!
+
+1354
+01:42:22.179 --> 01:42:23.764
+<i>What a surprise.</i>
+
+1355
+01:42:24.473 --> 01:42:25.683
+Strange.
+
+1356
+01:42:26.976 --> 01:42:29.145
+Unfortunately, I have another matter
+
+1357
+01:42:30.438 --> 01:42:31.439
+to attend to.
+
+1358
+01:42:36.610 --> 01:42:38.904
+What are you?
+
+1359
+01:42:39.071 --> 01:42:40.323
+You will soon find out.
+
+1360
+01:43:14.732 --> 01:43:18.444
+As magnificent as you are,
+you are still no match for me.
+
+1361
+01:43:22.615 --> 01:43:24.408
+We'll see about that.
+
+1362
+01:43:48.682 --> 01:43:50.810
+I am Diana of Themyscira,
+
+1363
+01:43:52.520 --> 01:43:54.605
+<i>daughter of Hippolyta,</i>
+
+1364
+01:43:55.481 --> 01:43:57.817
+Queen of the Amazons.
+
+1365
+01:44:01.070 --> 01:44:03.823
+And your wrath upon this world is over.
+
+1366
+01:44:20.631 --> 01:44:23.384
+In the name of all
+that is good in this world,
+
+1367
+01:44:23.551 --> 01:44:26.262
+I hereby complete
+the mission of the Amazons
+
+1368
+01:44:26.429 --> 01:44:28.264
+by ridding this world of you
+
+1369
+01:44:28.431 --> 01:44:29.515
+forever!
+
+1370
+01:45:36.749 --> 01:45:37.750
+<i>Diana?</i>
+
+1371
+01:45:43.839 --> 01:45:45.090
+Diana!
+
+1372
+01:45:49.261 --> 01:45:50.513
+I killed him.
+
+1373
+01:45:52.097 --> 01:45:54.266
+I killed him, but nothing stopped.
+
+1374
+01:45:56.435 --> 01:45:58.646
+You kill the God of War,
+you stop the war.
+
+1375
+01:45:58.812 --> 01:46:00.898
+Exactly what we have to do now.
+
+1376
+01:46:01.065 --> 01:46:02.483
+We need to stop the gas. Come on.
+
+1377
+01:46:02.650 --> 01:46:03.943
+No. All of this should have stopped!
+
+1378
+01:46:04.109 --> 01:46:05.110
+Diana...
+
+1379
+01:46:05.277 --> 01:46:07.112
+The fighting should have stopped.
+Why are they doing this?
+
+1380
+01:46:07.279 --> 01:46:09.281
+I don't know! I don't know.
+
+1381
+01:46:09.448 --> 01:46:11.116
+Ares is dead.
+
+1382
+01:46:11.283 --> 01:46:13.494
+They can stop fighting now.
+Why are they still fighting?
+
+1383
+01:46:13.661 --> 01:46:15.287
+Because, maybe it's them!
+
+1384
+01:46:15.829 --> 01:46:16.830
+Maybe...
+
+1385
+01:46:18.791 --> 01:46:21.418
+Maybe people aren't always good.
+
+1386
+01:46:22.294 --> 01:46:24.171
+Ares or no Ares,
+
+1387
+01:46:25.464 --> 01:46:28.842
+maybe it's just who they are.
+
+1388
+01:46:31.679 --> 01:46:33.055
+- Diana...
+- No.
+
+1389
+01:46:33.222 --> 01:46:34.723
+Diana, we can talk about this later.
+
+1390
+01:46:34.890 --> 01:46:35.975
+- I need you to come with me.
+- No. No.
+
+1391
+01:46:36.141 --> 01:46:38.060
+After everything I saw, it can't be!
+
+1392
+01:46:38.227 --> 01:46:39.687
+It cannot be!
+
+1393
+01:46:40.312 --> 01:46:42.064
+They were killing each other.
+
+1394
+01:46:42.231 --> 01:46:44.984
+Killing people they cannot see.
+Children...
+
+1395
+01:46:45.150 --> 01:46:46.694
+Children!
+
+1396
+01:46:46.902 --> 01:46:49.321
+No, it had to be him.
+It cannot be them!
+
+1397
+01:46:49.488 --> 01:46:51.907
+Diana, people... I...
+
+1398
+01:46:52.074 --> 01:46:53.576
+She was right.
+
+1399
+01:46:54.159 --> 01:46:55.160
+My mother was right.
+
+1400
+01:46:55.327 --> 01:46:57.246
+She said,
+"The world of men do not deserve you."
+
+1401
+01:46:57.413 --> 01:46:59.290
+They don't deserve our help, Steve.
+
+1402
+01:46:59.456 --> 01:47:01.584
+- It's not about deserve!
+- They don't deserve our help.
+
+1403
+01:47:01.750 --> 01:47:03.586
+Maybe we don't!
+
+1404
+01:47:05.212 --> 01:47:07.464
+But it's not about that.
+It's about what you believe.
+
+1405
+01:47:08.507 --> 01:47:11.343
+You don't think I get it
+after what I've seen out there?
+
+1406
+01:47:13.512 --> 01:47:16.181
+You don't think I wish I could tell you
+that it was one bad guy to blame?
+
+1407
+01:47:17.057 --> 01:47:18.559
+It's not!
+
+1408
+01:47:20.936 --> 01:47:22.563
+We're all to blame.
+
+1409
+01:47:22.855 --> 01:47:23.856
+I am not.
+
+1410
+01:47:25.399 --> 01:47:27.192
+But maybe I am!
+
+1411
+01:47:31.155 --> 01:47:32.239
+Please.
+
+1412
+01:47:32.406 --> 01:47:34.199
+If you believe that this war should stop,
+
+1413
+01:47:34.366 --> 01:47:36.118
+if you want to stop it,
+
+1414
+01:47:36.285 --> 01:47:38.537
+help me stop it right now.
+
+1415
+01:47:40.247 --> 01:47:43.083
+Because, if you don't,
+they will kill thousands more.
+
+1416
+01:47:43.709 --> 01:47:45.669
+Please, please come with me.
+
+1417
+01:47:45.836 --> 01:47:47.379
+I have to go.
+
+1418
+01:47:52.926 --> 01:47:55.387
+I have to go.
+
+1419
+01:48:07.232 --> 01:48:08.233
+Hey! Hey!
+
+1420
+01:48:12.738 --> 01:48:14.156
+- Where's Diana?
+- We're on our own.
+
+1421
+01:48:14.323 --> 01:48:16.784
+- What?
+- What do you see, Charlie?
+
+1422
+01:48:17.493 --> 01:48:19.119
+<i>Looks like a bunch of gas bombs</i>
+
+1423
+01:48:19.286 --> 01:48:21.914
+but I can't see where they're taking them.
+
+1424
+01:48:22.081 --> 01:48:23.415
+<i>How are we going to get in there?</i>
+
+1425
+01:48:24.083 --> 01:48:26.126
+I've got an idea. Come on, guys.
+
+1426
+01:48:26.293 --> 01:48:27.419
+Come on!
+
+1427
+01:48:41.266 --> 01:48:42.810
+Who's there?
+
+1428
+01:48:55.489 --> 01:48:57.032
+Sir Patrick.
+
+1429
+01:48:57.783 --> 01:49:02.121
+You were right, Diana.
+They don't deserve our help.
+
+1430
+01:49:03.288 --> 01:49:07.251
+They only deserve destruction.
+
+1431
+01:49:08.293 --> 01:49:09.712
+You...
+
+1432
+01:49:11.630 --> 01:49:13.632
+You're him.
+
+1433
+01:49:17.052 --> 01:49:18.470
+I am.
+
+1434
+01:49:19.054 --> 01:49:23.976
+But I am not what you thought I was.
+
+1435
+01:49:44.121 --> 01:49:45.706
+What is it?
+
+1436
+01:49:46.999 --> 01:49:48.417
+The future.
+
+1437
+01:49:53.005 --> 01:49:55.174
+I am not your enemy, Diana.
+
+1438
+01:49:57.009 --> 01:50:00.846
+I am the only one who truly knows you.
+
+1439
+01:50:01.013 --> 01:50:05.434
+And who truly knows them, as you now do.
+
+1440
+01:50:07.853 --> 01:50:11.690
+They have always been,
+and always will be
+
+1441
+01:50:11.857 --> 01:50:15.694
+weak, cruel, selfish,
+
+1442
+01:50:15.861 --> 01:50:19.031
+and capable of the greatest horrors.
+
+1443
+01:50:28.373 --> 01:50:29.875
+All I ever wanted
+
+1444
+01:50:30.042 --> 01:50:35.005
+was for the Gods to see how evil
+my father's creation was.
+
+1445
+01:50:36.924 --> 01:50:38.634
+But they refused.
+
+1446
+01:50:38.801 --> 01:50:40.052
+I am Diana of Themyscira...
+
+1447
+01:50:40.219 --> 01:50:41.220
+So I destroyed them.
+
+1448
+01:50:41.386 --> 01:50:43.388
+...daughter of Hippolyta,
+
+1449
+01:50:43.555 --> 01:50:44.681
+and I'm here to complete her--
+
+1450
+01:50:53.565 --> 01:50:54.817
+The Godkiller...
+
+1451
+01:50:57.861 --> 01:50:59.780
+My dear child,
+
+1452
+01:51:01.156 --> 01:51:03.659
+that is not the Godkiller.
+
+1453
+01:51:06.161 --> 01:51:07.704
+You are.
+
+1454
+01:51:10.415 --> 01:51:13.418
+Only a god can kill another god.
+
+1455
+01:51:14.419 --> 01:51:18.340
+Zeus left the child he had
+with the Queen of the Amazons
+
+1456
+01:51:18.507 --> 01:51:20.592
+as a weapon to use against me.
+
+1457
+01:51:20.759 --> 01:51:22.594
+No. You liar.
+
+1458
+01:51:24.304 --> 01:51:26.765
+I compel you to tell me the truth.
+
+1459
+01:51:29.101 --> 01:51:30.811
+I am.
+
+1460
+01:51:56.962 --> 01:51:59.339
+I am not the God of War, Diana.
+
+1461
+01:51:59.506 --> 01:52:02.217
+I am the God of Truth.
+
+1462
+01:52:03.510 --> 01:52:05.012
+Mankind
+
+1463
+01:52:05.637 --> 01:52:07.806
+stole this world from us.
+
+1464
+01:52:10.475 --> 01:52:14.021
+<i>They ruined it, day by day.</i>
+
+1465
+01:52:14.187 --> 01:52:18.358
+<i>And I, the only one
+wise enough to see it,</i>
+
+1466
+01:52:20.027 --> 01:52:22.779
+<i>was left too weak to stop them.</i>
+
+1467
+01:52:23.488 --> 01:52:27.117
+<i>All these years,
+I have struggled alone,</i>
+
+1468
+01:52:27.284 --> 01:52:29.202
+<i>whispering into their ears.</i>
+
+1469
+01:52:29.369 --> 01:52:34.207
+<i>Ideas, inspiration for formulas,</i>
+
+1470
+01:52:35.000 --> 01:52:36.627
+<i>weapons,</i>
+
+1471
+01:52:39.129 --> 01:52:41.632
+but I don't make them use them.
+
+1472
+01:52:42.507 --> 01:52:44.593
+They start these wars on their own.
+
+1473
+01:52:45.719 --> 01:52:49.514
+<i>All I do is orchestrate an armistice
+I know they cannot keep,</i>
+
+1474
+01:52:49.681 --> 01:52:52.225
+<i>in the hope they will destroy themselves.</i>
+
+1475
+01:52:53.977 --> 01:52:56.021
+<i>But it has never been enough.</i>
+
+1476
+01:52:57.689 --> 01:52:59.441
+Until you.
+
+1477
+01:53:01.485 --> 01:53:05.739
+<i>When you first arrived,
+I was going to crush you.</i>
+
+1478
+01:53:06.239 --> 01:53:09.493
+<i>But I knew that if only you could see</i>
+
+1479
+01:53:09.660 --> 01:53:12.496
+what the other gods could not,
+
+1480
+01:53:14.873 --> 01:53:19.419
+then you would join me,
+and with our powers combined,
+
+1481
+01:53:19.586 --> 01:53:23.590
+we could finally end all the pain,
+all the suffering,
+
+1482
+01:53:23.757 --> 01:53:26.468
+the destruction they bring.
+
+1483
+01:53:26.635 --> 01:53:31.932
+And we could return this world
+to the paradise it was before them.
+
+1484
+01:53:33.392 --> 01:53:35.018
+<i>Forever.</i>
+
+1485
+01:53:37.896 --> 01:53:39.439
+<i>I...</i>
+
+1486
+01:53:44.111 --> 01:53:46.989
+I could never be a part of that.
+
+1487
+01:53:50.242 --> 01:53:52.869
+My dear, I don't want to fight you.
+
+1488
+01:53:53.954 --> 01:53:55.330
+<i>But, if I must...</i>
+
+1489
+01:54:04.798 --> 01:54:06.591
+- Steve!
+- Come on, let's go!
+
+1490
+01:54:07.300 --> 01:54:08.427
+<i>Sammy, let's go!</i>
+
+1491
+01:54:09.052 --> 01:54:10.721
+Get this plane out of here!
+
+1492
+01:54:40.667 --> 01:54:45.088
+Oh, my dear, you have so much to learn.
+
+1493
+01:55:10.197 --> 01:55:12.532
+Oh, my God!
+
+1494
+01:55:12.699 --> 01:55:13.992
+What are we gonna do?
+
+1495
+01:55:15.827 --> 01:55:18.038
+There's not much we can do,
+
+1496
+01:55:18.497 --> 01:55:19.998
+if that's who I think it is.
+
+1497
+01:55:26.004 --> 01:55:27.923
+But we can stop that plane.
+
+1498
+01:55:40.977 --> 01:55:43.021
+<i>If we can get on the radio,</i>
+
+1499
+01:55:43.188 --> 01:55:45.065
+we can ask Flying Corps to shoot her down.
+
+1500
+01:55:45.232 --> 01:55:48.360
+No. If it crashes, it'll wipe everyone out
+for 50 square miles!
+
+1501
+01:55:48.527 --> 01:55:49.528
+We gotta ground it!
+
+1502
+01:55:49.694 --> 01:55:51.530
+Bad news. It's on a timer.
+
+1503
+01:55:51.696 --> 01:55:54.074
+If we ground it here,
+it's the same thing.
+
+1504
+01:56:01.039 --> 01:56:02.833
+Is it flammable, Chief?
+
+1505
+01:56:02.999 --> 01:56:06.378
+Yeah, she said it's hydrogen.
+It's flammable.
+
+1506
+01:56:13.426 --> 01:56:15.720
+I need you guys to clear me a path
+to that plane.
+
+1507
+01:56:15.887 --> 01:56:18.098
+- No, Steve!
+- Hey, Steve!
+
+1508
+01:56:19.391 --> 01:56:20.392
+Come on!
+
+1509
+01:57:03.768 --> 01:57:05.562
+Come on! This way! Steve!
+
+1510
+01:57:15.947 --> 01:57:17.157
+- Go, Steve, come on.
+- Go!
+
+1511
+01:57:17.949 --> 01:57:19.326
+Steve!
+
+1512
+01:57:22.162 --> 01:57:24.122
+- Go, Steve. Come on.
+- Run, run!
+
+1513
+01:58:02.244 --> 01:58:05.664
+Let's see what kind of god you really are.
+
+1514
+01:58:31.856 --> 01:58:34.526
+<i>You will help me destroy them, Diana,</i>
+
+1515
+01:58:38.655 --> 01:58:40.532
+<i>or you will die.</i>
+
+1516
+01:58:50.500 --> 01:58:52.752
+<i>Come on, come on.
+Let's go, go, go!</i>
+
+1517
+01:58:54.796 --> 01:58:57.048
+- Move it, boys! Now!
+- Let's go! Run!
+
+1518
+01:59:22.907 --> 01:59:25.618
+Is that all you have to offer?
+
+1519
+01:59:41.843 --> 01:59:45.764
+It is futile to imagine you can win.
+
+1520
+01:59:46.556 --> 01:59:48.183
+Give up, Diana.
+
+1521
+01:59:48.350 --> 01:59:49.351
+<i>Guys, I'm out.</i>
+
+1522
+01:59:52.354 --> 01:59:53.605
+Chief! Anything left?
+
+1523
+01:59:53.772 --> 01:59:54.856
+I got nothing.
+
+1524
+01:59:55.023 --> 01:59:56.066
+- Anything!
+<i>- No.</i>
+
+1525
+02:00:14.000 --> 02:00:15.168
+Steve.
+
+1526
+02:01:01.548 --> 02:01:02.966
+Steve...
+
+1527
+02:01:06.469 --> 02:01:08.847
+No!
+
+1528
+02:01:43.798 --> 02:01:46.092
+<i>Yes, Diana!</i>
+
+1529
+02:01:46.259 --> 02:01:48.970
+<i>Take them all!</i>
+
+1530
+02:01:49.137 --> 02:01:52.098
+<i>Finally, you see.</i>
+
+1531
+02:01:52.724 --> 02:01:55.143
+Look at this world.
+
+1532
+02:01:56.060 --> 02:01:58.855
+<i>Mankind did this, not me.</i>
+
+1533
+02:02:00.064 --> 02:02:01.983
+<i>They are ugly,</i>
+
+1534
+02:02:02.150 --> 02:02:04.235
+<i>filled with hatred,</i>
+
+1535
+02:02:04.402 --> 02:02:05.653
+<i>weak,</i>
+
+1536
+02:02:05.820 --> 02:02:08.907
+<i>just like your Captain Trevor.</i>
+
+1537
+02:02:09.073 --> 02:02:11.910
+Gone, and left you nothing.
+
+1538
+02:02:12.744 --> 02:02:14.913
+<i>And for what?</i>
+
+1539
+02:02:15.330 --> 02:02:16.623
+<i>Pathetic!</i>
+
+1540
+02:02:18.458 --> 02:02:19.751
+He deserved to burn!
+
+1541
+02:02:30.762 --> 02:02:34.474
+<i>Look at her and tell me I'm wrong.</i>
+
+1542
+02:02:43.608 --> 02:02:47.612
+<i>She is the perfect example of these humans</i>
+
+1543
+02:02:49.405 --> 02:02:53.201
+<i>and unworthy of your sympathy in every way.</i>
+
+1544
+02:02:54.452 --> 02:02:56.955
+Destroy her, Diana.
+
+1545
+02:02:57.622 --> 02:03:01.042
+<i>You know that she deserves it.
+They all do.</i>
+
+1546
+02:03:04.629 --> 02:03:06.089
+Do it!
+
+1547
+02:03:10.802 --> 02:03:12.470
+<i>Diana!</i>
+
+1548
+02:03:15.848 --> 02:03:17.267
+<i>Diana...</i>
+
+1549
+02:03:26.025 --> 02:03:27.026
+What?
+
+1550
+02:03:28.152 --> 02:03:29.821
+I have to go.
+
+1551
+02:03:32.532 --> 02:03:33.992
+What are you saying?
+
+1552
+02:03:34.367 --> 02:03:35.368
+Steve,
+
+1553
+02:03:36.035 --> 02:03:38.329
+whatever it is, I can do it.
+
+1554
+02:03:38.496 --> 02:03:39.497
+No. No.
+
+1555
+02:03:39.664 --> 02:03:41.291
+- Let me do it.
+- No.
+
+1556
+02:03:41.457 --> 02:03:43.001
+It has to be me.
+
+1557
+02:03:43.167 --> 02:03:44.961
+It has to be me.
+
+1558
+02:03:45.128 --> 02:03:48.131
+I can save today.
+You could save the world.
+
+1559
+02:03:56.973 --> 02:03:59.601
+I wish we had more time.
+
+1560
+02:04:00.184 --> 02:04:02.687
+What? What are you saying?
+
+1561
+02:04:05.356 --> 02:04:06.524
+I love you!
+
+1562
+02:04:18.536 --> 02:04:19.829
+You're wrong about them.
+
+1563
+02:04:29.756 --> 02:04:31.507
+They're everything you say,
+
+1564
+02:04:32.258 --> 02:04:34.010
+but so much more.
+
+1565
+02:04:34.177 --> 02:04:35.553
+Lies!
+
+1566
+02:05:01.788 --> 02:05:05.416
+They do not deserve your protection!
+
+1567
+02:05:07.210 --> 02:05:08.378
+It's not about deserve.
+
+1568
+02:05:13.257 --> 02:05:15.176
+It's about what you believe.
+
+1569
+02:05:18.429 --> 02:05:19.931
+And I believe in love.
+
+1570
+02:05:20.098 --> 02:05:24.394
+Then I will destroy you!
+
+1571
+02:05:52.296 --> 02:05:53.965
+Goodbye, brother.
+
+1572
+02:09:26.218 --> 02:09:28.554
+<i>I used to want to save the world.</i>
+
+1573
+02:09:29.722 --> 02:09:33.476
+<i>To end war and bring peace to mankind.</i>
+
+1574
+02:09:34.060 --> 02:09:37.897
+<i>But then I glimpsed the darkness
+that lives within their light</i>
+
+1575
+02:09:38.814 --> 02:09:41.150
+<i>and learned that inside every one of them,</i>
+
+1576
+02:09:41.734 --> 02:09:43.986
+<i>there will always be both.</i>
+
+1577
+02:09:44.862 --> 02:09:47.740
+<i>A choice each must make for themselves.</i>
+
+1578
+02:09:47.907 --> 02:09:51.327
+<i>Something no hero will ever defeat.</i>
+
+1579
+02:09:53.037 --> 02:09:54.038
+<i>And now I know</i>
+
+1580
+02:09:54.997 --> 02:09:59.627
+<i>that only love can truly save the world.</i>
+
+1581
+02:10:01.504 --> 02:10:03.172
+<i>So, I stay,</i>
+
+1582
+02:10:03.339 --> 02:10:05.508
+<i>I fight, and I give,</i>
+
+1583
+02:10:08.260 --> 02:10:10.262
+<i>for the world I know can be.</i>
+
+1584
+02:10:15.017 --> 02:10:16.227
+<i>This is my mission now.</i>
+
+1585
+02:10:19.605 --> 02:10:20.940
+<i>Forever.</i>
+
+1586
+02:21:07.711 --> 02:21:08.712
+English - SDH

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -8,13 +8,16 @@ import { parse } from '..'
 const readFile = promisify(fs.readFile)
 
 test('parse all examples', async t => {
-  const subtitles = await glob(path.join(__dirname, '/examples/*.srt'))
+  const srt = await glob(path.join(__dirname, '/examples/*.srt'))
 
-  Object.keys(subtitles).forEach(async filepath => {
-    const basename = path.basename(filepath, '.srt')
-    const value = await readFile(path.join(__dirname, `/examples/${basename}.json`), 'utf8')
-    t.deepEqual(subtitles[filepath], parse(value))
-  })
+  await Promise.all(
+    Object.keys(srt).map(async filepath => {
+      const basename = path.basename(filepath, '.srt')
+      const json = await readFile(path.join(__dirname, `/examples/${basename}.json`), 'utf8')
+      const subtitles = JSON.parse(json)
+      t.deepEqual(parse(srt[filepath]), subtitles)
+    })
+  )
 })
 
 test('parse SRT captions', t => {

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -8,14 +8,22 @@ import { stringify } from '..'
 const readFile = promisify(fs.readFile)
 
 test('stringify all examples', async t => {
-  const subtitles = await glob(path.join(__dirname, '/examples/*.json'))
+  const srt = await glob(path.join(__dirname, '/examples/*.srt'))
 
-  Object.keys(subtitles).forEach(async filepath => {
-    const basename = path.basename(filepath, '.json')
-    const value = await readFile(path.join(__dirname, `/examples/${basename}.srt`), 'utf8')
-    const expected = JSON.parse(subtitles[filepath])
-    t.deepEqual(expected, stringify(value))
-  })
+  await Promise.all(
+    Object.keys(srt).map(async filepath => {
+      const basename = path.basename(filepath, '.srt')
+      const json = await readFile(path.join(__dirname, `/examples/${basename}.json`), 'utf8')
+      const subtitles = JSON.parse(json)
+      const normalizedSrt = srt[filepath]
+        .trim()
+        .concat('\n')
+        .replace(/\r\n/g, '\n')
+        .replace(/\n{3,}/g, '\n\n')
+
+      t.deepEqual(stringify(subtitles), normalizedSrt)
+    })
+  )
 })
 
 test('stringify captions with timestamp in SRT format', t => {

--- a/test/stringifyVtt.test.js
+++ b/test/stringifyVtt.test.js
@@ -1,0 +1,65 @@
+import test from 'ava'
+import fs from 'fs'
+import path from 'path'
+import promisify from 'pify'
+import glob from 'glob-contents'
+import { stringifyVtt } from '..'
+
+const readFile = promisify(fs.readFile)
+
+test('stringify all examples', async t => {
+  const vtt = await glob(path.join(__dirname, '/examples/*.vtt'))
+
+  await Promise.all(
+    Object.keys(vtt).map(async filepath => {
+      const basename = path.basename(filepath, '.vtt')
+      const json = await readFile(path.join(__dirname, `/examples/${basename}.json`), 'utf8')
+      const subtitles = JSON.parse(json)
+      const normalizedVtt = vtt[filepath]
+        .trim()
+        .concat('\n')
+        .replace(/\r\n/g, '\n')
+        .replace(/\n{3,}/g, '\n\n')
+
+      t.deepEqual(stringifyVtt(subtitles), normalizedVtt)
+    })
+  )
+})
+
+test('stringify captions with timestamp in WebVTT format', t => {
+  const captions = [
+    {
+      start: 940647,
+      end: 954489,
+      text: 'Hi.'
+    },
+    {
+      start: 7956415,
+      end: 7957758,
+      text: 'Lois Lane.',
+      settings: 'align:middle line:90%'
+    },
+    {
+      start: 7958584,
+      end: 7960120,
+      text: 'Welcome to the Planet.'
+    }
+  ]
+
+  const expected = `WEBVTT
+
+1
+00:15:40.647 --> 00:15:54.489
+Hi.
+
+2
+02:12:36.415 --> 02:12:37.758 align:middle line:90%
+Lois Lane.
+
+3
+02:12:38.584 --> 02:12:40.120
+Welcome to the Planet.
+  `.trim().concat('\n')
+
+  t.is(stringifyVtt(captions), expected)
+})

--- a/test/toVttTime.test.js
+++ b/test/toVttTime.test.js
@@ -1,0 +1,28 @@
+import test from 'ava'
+import { toVttTime } from '..'
+
+test('should convert time from milliseconds to WebVTT format', t => {
+  const time1 = {
+    srt: '00:02:22.542',
+    ms: 120000 + 22000 + 542
+  }
+
+  const time2 = {
+    srt: '01:51:58.219',
+    ms: 3600000 + 3060000 + 58000 + 219
+  }
+
+  const time3 = {
+    srt: '00:00:00.000',
+    ms: 0
+  }
+
+  t.is(toVttTime(time1.ms), time1.srt)
+  t.is(toVttTime(time2.ms), time2.srt)
+  t.is(toVttTime(time3.ms), time3.srt)
+})
+
+test('should return the given values that are not numbers', t => {
+  t.is(toVttTime('01:51:58,219'), '01:51:58,219')
+  t.is(toVttTime('string'), 'string')
+})


### PR DESCRIPTION
The async tests for `parse` and `stringify` which were causing problems during CI should also be fixed. The tests were broken, but because the function wasn't waiting on the promises it only failed occasionally when the promises resolved before the test runner completed. The tests now wait on all promises, and they pass.