### PR TITLE
Add option to drop malformed lines when parsing (#27)

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,8 +10,13 @@ import parseTimestamps from './parseTimestamps'
  * @return {Array} subtitles
  */
 
-export default function parse (srtOrVtt) {
+export default function parse (srtOrVtt, options) {
   if (!srtOrVtt) return []
+  options = options || {
+    skipInvalidCaptions: false,
+    errorHandler: null,
+    skipContiguousErrors: true
+  }
 
   const source = srtOrVtt
     .trim()
@@ -21,30 +26,50 @@ export default function parse (srtOrVtt) {
     .replace(/^WEBVTT.*\n{2}/, '')
     .split('\n')
 
+  var lastWasSuccessful = true
+
   return source.reduce((captions, row, index) => {
     const caption = captions[captions.length - 1]
 
-    if (!caption.index) {
-      if (/^\d+$/.test(row)) {
-        caption.index = parseInt(row, 10)
+    try {
+      if (!caption.index) {
+        if (/^\d+$/.test(row)) {
+          caption.index = parseInt(row, 10)
+          return captions
+        }
+      }
+
+      if (!caption.hasOwnProperty('start')) {
+        Object.assign(caption, parseTimestamps(row))
         return captions
       }
-    }
 
-    if (!caption.hasOwnProperty('start')) {
-      Object.assign(caption, parseTimestamps(row))
-      return captions
-    }
-
-    if (row === '') {
-      delete caption.index
-      if (index !== source.length - 1) {
-        captions.push({})
+      if (row === '') {
+        delete caption.index
+        if (index !== source.length - 1) {
+          captions.push({})
+        }
+      } else {
+        caption.text = caption.text
+          ? caption.text + '\n' + row
+          : row
       }
-    } else {
-      caption.text = caption.text
-        ? caption.text + '\n' + row
-        : row
+
+      lastWasSuccessful = true
+    } catch (error) {
+      if (!options.skipInvalidCaptions) {
+        throw error
+      }
+
+      if (lastWasSuccessful || !options.skipContiguousErrors) {
+        if (typeof options.errorHandler === 'function') {
+          options.errorHandler({index: index, row: row, error: error})
+        }
+      }
+
+      lastWasSuccessful = false
+
+      captions[captions.length - 1] = {}
     }
 
     return captions

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -147,3 +147,31 @@ Hi.`
   t.deepEqual(value, expected)
 })
 
+test('parse text that is partially malformed', t => {
+  const srt = `
+1
+00:00:00,000 --> 00:00:00,100Something something something... dark side
+ 
+3
+
+2
+00:00:00,100 --> 00:00:00,200
+Hi.`
+  const value = parse(srt, {
+    skipInvalidCaptions: true,
+    errorHandler: function (error) {
+      console.log(error)
+    },
+    skipContiguousErrors: true
+  })
+
+  const expected = [
+    {
+      start: 100,
+      end: 200,
+      text: 'Hi.'
+    }
+  ]
+
+  t.deepEqual(value, expected)
+})


### PR DESCRIPTION
Based on the specification of the issue #27, I implemented the functionality to optionally drop malformed subtitles. Any comments or suggestions for improvement are welcome. :)

Additionally, I also added some options not originally stated in the issue, such as a way of handling any errors that might be found (for the app to show them to the user if needed, perhaps).

I need this feature for a project I'm working on, and in the meantime I am fine depending on the local version of the module, but I would greatly appreciate if this feature could be merged into the official module and published on npm.