### PR TITLE
Added support for WebVTT with headers

### DIFF
--- a/dist/subtitle.bundle.js
+++ b/dist/subtitle.bundle.js
@@ -374,7 +374,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function parse(srtOrVtt) {
   if (!srtOrVtt) return [];
 
-  var source = srtOrVtt.trim().concat('\n').replace(/\r\n/g, '\n').replace(/\n{3,}/g, '\n\n').replace(/^WEBVTT.*\n{2}/, '').split('\n');
+  var source = srtOrVtt.trim().concat('\n').replace(/\r\n/g, '\n').replace(/\n{3,}/g, '\n\n').replace(/^WEBVTT.*\n(?:.*: .*\n)*\n/, '').split('\n');
 
   return source.reduce(function (captions, row, index) {
     var caption = captions[captions.length - 1];

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -18,7 +18,7 @@ export default function parse (srtOrVtt) {
     .concat('\n')
     .replace(/\r\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
-    .replace(/^WEBVTT.*\n{2}/, '')
+    .replace(/^WEBVTT.*\n(?:.*: .*\n)*\n/, '')
     .split('\n')
 
   return source.reduce((captions, row, index) => {

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -99,6 +99,49 @@ Welcome to the Planet.
   t.deepEqual(value, expected)
 })
 
+test('parse VTT caption with headers', t => {
+  const vtt = `
+WEBVTT - Test VTT cues
+Kind: captions
+Language: en-US
+
+1
+12:34.647 --> 12:35.489 align:middle line:90%
+Hi.
+
+2
+12:36.415 --> 02:12:37.758 align:start line:90%
+Lois Lane.
+
+02:12:38.584 --> 02:12:40.120
+Welcome to the Planet.
+  `.trim().concat('\n')
+
+  const value = parse(vtt)
+
+  const expected = [
+    {
+      start: 754647,
+      end: 755489,
+      settings: 'align:middle line:90%',
+      text: 'Hi.'
+    },
+    {
+      start: 756415,
+      end: 7957758,
+      settings: 'align:start line:90%',
+      text: 'Lois Lane.'
+    },
+    {
+      start: 7958584,
+      end: 7960120,
+      text: 'Welcome to the Planet.'
+    }
+  ]
+
+  t.deepEqual(value, expected)
+})
+
 test('it should return an empty array', t => {
   t.deepEqual(parse(), [])
 })


### PR DESCRIPTION
WebVTT can have optional header metadata, like this:

```
WEBVTT
Kind: captions
Language: en-US
```