### PR TITLE
#36 support seperated texts in subtitles

### DIFF
--- a/dist/subtitle.bundle.js
+++ b/dist/subtitle.bundle.js
@@ -392,7 +392,7 @@ function parse(srtOrVtt) {
       var timestamp = (0, _parseTimestamps2.default)(row);
       if (timestamp) {
         Object.assign(caption, timestamp);
-      } else if (captions.length > 2) {
+      } else if (captions.length > 1) {
         captions[captions.length - 2].text += '\n' + row;
       }
       return captions;

--- a/dist/subtitle.bundle.js
+++ b/dist/subtitle.bundle.js
@@ -252,14 +252,16 @@ var RE = /^((?:\d{2,}:)?\d{2}:\d{2}[,.]\d{3}) --> ((?:\d{2,}:)?\d{2}:\d{2}[,.]\d
 
 function parseTimestamps(value) {
   var match = RE.exec(value);
-  var cue = {
-    start: (0, _toMS2.default)(match[1]),
-    end: (0, _toMS2.default)(match[2])
-  };
-  if (match[3]) {
-    cue.settings = match[3];
+  if (match) {
+    var cue = {
+      start: (0, _toMS2.default)(match[1]),
+      end: (0, _toMS2.default)(match[2])
+    };
+    if (match[3]) {
+      cue.settings = match[3];
+    }
+    return cue;
   }
-  return cue;
 }
 
 /***/ }),
@@ -387,7 +389,12 @@ function parse(srtOrVtt) {
     }
 
     if (!caption.hasOwnProperty('start')) {
-      Object.assign(caption, (0, _parseTimestamps2.default)(row));
+      var timestamp = (0, _parseTimestamps2.default)(row);
+      if (timestamp) {
+        Object.assign(caption, timestamp);
+      } else if (captions.length > 2) {
+        captions[captions.length - 2].text += '\n' + row;
+      }
       return captions;
     }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -32,7 +32,12 @@ export default function parse (srtOrVtt) {
     }
 
     if (!caption.hasOwnProperty('start')) {
-      Object.assign(caption, parseTimestamps(row))
+      const timestamp = parseTimestamps(row)
+      if (timestamp) {
+        Object.assign(caption, timestamp)
+      } else if (captions.length > 2) {
+        captions[captions.length - 2].text += '\n' + row
+      }
       return captions
     }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -35,7 +35,7 @@ export default function parse (srtOrVtt) {
       const timestamp = parseTimestamps(row)
       if (timestamp) {
         Object.assign(caption, timestamp)
-      } else if (captions.length > 2) {
+      } else if (captions.length > 1) {
         captions[captions.length - 2].text += '\n' + row
       }
       return captions

--- a/lib/parseTimestamps.js
+++ b/lib/parseTimestamps.js
@@ -19,12 +19,14 @@ const RE = /^((?:\d{2,}:)?\d{2}:\d{2}[,.]\d{3}) --> ((?:\d{2,}:)?\d{2}:\d{2}[,.]
 
 export default function parseTimestamps (value) {
   const match = RE.exec(value)
-  const cue = {
-    start: toMS(match[1]),
-    end: toMS(match[2])
+  if (match) {
+    const cue = {
+      start: toMS(match[1]),
+      end: toMS(match[2])
+    }
+    if (match[3]) {
+      cue.settings = match[3]
+    }
+    return cue
   }
-  if (match[3]) {
-    cue.settings = match[3]
-  }
-  return cue
 }

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -190,3 +190,29 @@ Hi.`
   t.deepEqual(value, expected)
 })
 
+test('parse separated texts', t => {
+  const srt = `
+1
+00:00:00,000 --> 00:00:00,100
+Dear Michael. Of course it's you.
+
+Who else could they send?
+
+2
+00:00:00,100 --> 00:00:00,200
+Who else could be trusted?`
+  const value = parse(srt)
+  const expected = [
+    {
+      start: 0,
+      end: 100,
+      text: 'Dear Michael. Of course it\'s you.\nWho else could they send?\n'
+    }, {
+      start: 100,
+      end: 200,
+      text: 'Who else could be trusted?'
+    }
+  ]
+
+  t.deepEqual(value, expected)
+})


### PR DESCRIPTION
I see that some subtitles which are not few has used a blank line in their texts and that makes the problem, I know its not standard but they are working in some players.

for example the following caption make the problem

278
00:23:52,417 --> 00:23:53,292
Hang in there,

Master Liu!

279
.....