### PR TITLE
update version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "subtitle",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Just a tiny nit, but the package version in `package-lock.json` is out of sync with `package.json`.

This PR fixes that.