### PR TITLE
Ignore VTT format comments

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -4,7 +4,7 @@ import { Node, RE_TIMESTAMP, parseTimestamps } from '.'
 export type Pusher = (node: Node) => void
 
 export interface ParseState {
-  expect: 'header' | 'id' | 'timestamp' | 'text'
+  expect: 'header' | 'id' | 'timestamp' | 'text' | 'vtt_comment'
   row: number
   hasContentStarted: boolean
   isWebVTT: boolean
@@ -36,6 +36,10 @@ export class Parser {
     return RE_TIMESTAMP.test(line)
   }
 
+  private isVttComment(line: string): boolean {
+    return /^NOTE/.test(line)
+  }
+
   private getError(expected: string, index: number, row: string): Error {
     return new Error(
       `expected ${expected} at row ${index + 1}, but received: "${row}"`
@@ -57,7 +61,8 @@ export class Parser {
       header: this.parseHeader,
       id: this.parseId,
       timestamp: this.parseTimestamp,
-      text: this.parseText
+      text: this.parseText,
+      vtt_comment: this.parseVttComment
     }[this.state.expect]
 
     parse.call(this, contents)
@@ -98,8 +103,21 @@ export class Parser {
       this.pushNode()
     }
 
-    if (!this.isIndex(line)) {
-      this.parseTimestamp(line)
+    if (this.isIndex(line)) return
+
+    if (this.state.isWebVTT && this.isVttComment(line)) {
+      this.state.expect = 'vtt_comment'
+      return
+    }
+
+    this.parseTimestamp(line)
+  }
+
+  private parseVttComment(line: string) {
+    this.state.expect = 'vtt_comment'
+
+    if (line.trim() === '') {
+      this.state.expect = 'id'
     }
   }
 
@@ -120,7 +138,12 @@ export class Parser {
   }
 
   private parseText(line: string) {
-    if (this.state.buffer.length > 0 && this.isTimestamp(line)) {
+    if (this.state.buffer.length === 0) {
+      this.state.buffer.push(line)
+      return
+    }
+
+    if (this.isTimestamp(line)) {
       const lastIndex = this.state.buffer.length - 1
 
       if (this.isIndex(this.state.buffer[lastIndex])) {
@@ -129,9 +152,16 @@ export class Parser {
 
       this.pushNode()
       this.parseTimestamp(line)
-    } else {
-      this.state.buffer.push(line)
+      return
     }
+
+    if (this.isVttComment(line)) {
+      this.pushNode()
+      this.parseVttComment(line)
+      return
+    }
+
+    this.state.buffer.push(line)
   }
 
   private pushNode(): void {

--- a/test/parseSync.test.ts
+++ b/test/parseSync.test.ts
@@ -172,6 +172,62 @@ Welcome to the Planet.
   `)
 })
 
+// https://w3c.github.io/webvtt/#introduction-comments
+test('parse VTT caption and ignore comments', () => {
+  const vtt = `
+WEBVTT - Test VTT Comments
+
+NOTE
+This file was written by Jill. I hope
+you enjoy reading it. Some things to
+bear in mind:
+- I was lip-reading, so the cues may
+not be 100% accurate
+- I didn’t pay too close attention to
+when the cues should start or end.
+
+00:01.000 --> 00:04.000
+Never drink liquid nitrogen.
+
+NOTE check next cue
+
+00:05.000 --> 00:09.000 align:middle line:90%
+— It will perforate your stomach.
+— You could die.
+
+NOTE end of file
+  `
+    .trim()
+    .concat('\n')
+
+  expect(parseSync(vtt)).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "data": "WEBVTT - Test VTT Comments",
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "end": 4000,
+          "start": 1000,
+          "text": "Never drink liquid nitrogen.",
+        },
+        "type": "cue",
+      },
+      Object {
+        "data": Object {
+          "end": 9000,
+          "settings": "align:middle line:90%",
+          "start": 5000,
+          "text": "— It will perforate your stomach.
+    — You could die.",
+        },
+        "type": "cue",
+      },
+    ]
+  `)
+})
+
 test('parse 00:00:00,000 caption', () => {
   const srt = `
 1


### PR DESCRIPTION
I've based the test on example 10 from the WebVTT spec: https://w3c.github.io/webvtt/#introduction-comments

All tests pass and coverage is 100%.