### PR TITLE
Remove decimals from ms

### DIFF
--- a/src/formatTimestamp.ts
+++ b/src/formatTimestamp.ts
@@ -10,7 +10,9 @@ export function formatTimestamp(
   const hours = date.getHours()
   const minutes = date.getMinutes()
   const seconds = date.getSeconds()
-  const ms = timestamp - (hours * 3600000 + minutes * 60000 + seconds * 1000)
+  const ms = Math.floor(
+    timestamp - (hours * 3600000 + minutes * 60000 + seconds * 1000)
+  )
 
   return `${padLeft(hours)}:${padLeft(minutes)}:${padLeft(seconds)}${
     options.format === 'WebVTT' ? '.' : ','


### PR DESCRIPTION
It can happen that ms is a value like `200,00000003`    
This removes the decimals, resulting in always having decimal as 3 digit