### PR TITLE
Implement filter as a Transform stream to fix piping

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,12 +1,11 @@
 import { Node } from '.'
-import { createDuplex } from './utils'
+import { Transform } from 'stream'
 
 export const filter = (callback: (node: Node) => boolean) =>
-  createDuplex({
-    write(chunk, _encoding, next) {
-      if (callback(chunk)) {
-        this.push(chunk)
-      }
-      next()
+  new Transform({
+    objectMode: true,
+    autoDestroy: false,
+    transform: function transform(chunk, _encoding, next) {
+      callback(chunk) ? next(null, chunk) : next()
     }
   })

--- a/test-utils.ts
+++ b/test-utils.ts
@@ -60,3 +60,11 @@ export const pipeline = (stream: Readable): Promise<NodeList> =>
     stream.on('error', reject)
     stream.on('finish', () => resolve(buffer))
   })
+
+export const streamToString = (stream: Readable): Promise<string> =>
+  new Promise((resolve, reject) => {
+    let buffer = ''
+    stream.on('data', (chunk: string) => buffer += chunk)
+    stream.on('error', reject)
+    stream.on('finish', () => resolve(buffer))
+  })

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -1,5 +1,5 @@
-import { createStreamFromString, pipeline } from '../test-utils'
-import { filter, parse } from '../src'
+import { createStreamFromString, pipeline, streamToString } from '../test-utils'
+import { filter, parse, stringify } from '../src'
 
 test('filter nodes', async () => {
   const stream = createStreamFromString(`
@@ -42,5 +42,42 @@ Welcome to the Planet.\n`)
         "type": "cue",
       },
     ]
+  `)
+})
+
+test('filter nodes and forward to the next stream', async () => {
+  const stream = createStreamFromString(`
+1
+02:12:34,647 --> 02:12:35,489
+Hi.
+
+2
+02:12:36,415 --> 02:12:37,758
+𝅘𝅥𝅮 Some Music 𝅘𝅥𝅮
+
+3
+02:12:38,584 --> 02:12:40,120
+Welcome to the Planet.\n`)
+
+  const data = await streamToString(
+    stream
+      .pipe(parse())
+      .pipe(
+        filter(node => !(node.type === 'cue' && node.data.text.includes('𝅘𝅥𝅮')))
+      )
+      .pipe(stringify({ format: 'WebVTT' }))
+  )
+
+  expect(data).toMatchInlineSnapshot(`
+    "WEBVTT
+
+    1
+    02:12:34.647 --> 02:12:35.489
+    Hi.
+
+    2
+    02:12:38.584 --> 02:12:40.120
+    Welcome to the Planet.
+    "
   `)
 })


### PR DESCRIPTION
On Node `14.16.0`, and presumably later, the `filter` implementation never completes when piped to a subsequent stream such as `stringify`. I have added a test for this in the first commit.

Changing the filter implementation from a Duplex stream to a Transform stream fixes this issue.

I'm not sure whether this used to work in older versions of Node.js. Based on [this issue](https://github.com/nodejs/node/issues/38654) it looks like something might have changed in the internal streams implementation in Node `14.1.0`.